### PR TITLE
feat(athena): scaffold AthenaMLX seam — MLXBacktestRunner + VectorizableStrategy [#112]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,11 @@ let package = Package(
         .library(name: "AthenaBrokers", targets: ["AthenaBrokers"]),
         .library(name: "AthenaData", targets: ["AthenaData"]),
         .library(name: "AthenaBacktest", targets: ["AthenaBacktest"]),
+        .library(name: "AthenaSweep", targets: ["AthenaSweep"]),
+        .library(name: "AthenaMLX", targets: ["AthenaMLX"]),
     ],
     targets: [
+        // MARK: - Core modules
         .target(name: "AthenaCore"),
         .target(name: "AthenaIndicators", dependencies: ["AthenaCore"]),
         .target(name: "AthenaBrokers", dependencies: ["AthenaCore"]),
@@ -23,6 +26,25 @@ let package = Package(
             name: "AthenaBacktest",
             dependencies: ["AthenaCore", "AthenaIndicators", "AthenaBrokers", "AthenaData"]
         ),
+
+        // MARK: - Sweep module (v0.4)
+        .target(
+            name: "AthenaSweep",
+            dependencies: ["AthenaCore", "AthenaBacktest"]
+        ),
+
+        // MARK: - MLX runner module (v0.5)
+        //
+        // Slice 1: seam only — delegates to EventDrivenRunner internally.
+        // Later slices add mlx-swift as a conditional macOS/iOS dependency
+        // and replace the delegation with real tensor dispatch behind
+        // `#if canImport(MLX)` guards.
+        .target(
+            name: "AthenaMLX",
+            dependencies: ["AthenaCore", "AthenaBacktest", "AthenaSweep"]
+        ),
+
+        // MARK: - Examples
         .executableTarget(
             name: "MACrossoverExample",
             dependencies: [
@@ -82,10 +104,53 @@ let package = Package(
             ],
             path: "Examples/TaxAware"
         ),
+        .executableTarget(
+            name: "ParameterSweepExample",
+            dependencies: [
+                "AthenaCore",
+                "AthenaIndicators",
+                "AthenaBrokers",
+                "AthenaData",
+                "AthenaBacktest",
+                "AthenaSweep",
+            ],
+            path: "Examples/ParameterSweep"
+        ),
+
+        // MARK: - Tests
         .testTarget(name: "AthenaCoreTests", dependencies: ["AthenaCore"]),
-        .testTarget(name: "AthenaIndicatorsTests", dependencies: ["AthenaIndicators", "AthenaCore"]),
-        .testTarget(name: "AthenaBrokersTests", dependencies: ["AthenaBrokers", "AthenaCore"]),
-        .testTarget(name: "AthenaDataTests", dependencies: ["AthenaData", "AthenaCore"]),
-        .testTarget(name: "AthenaBacktestTests", dependencies: ["AthenaBacktest", "AthenaCore", "AthenaIndicators", "AthenaBrokers", "AthenaData"]),
+        .testTarget(
+            name: "AthenaIndicatorsTests",
+            dependencies: ["AthenaIndicators", "AthenaCore"]
+        ),
+        .testTarget(
+            name: "AthenaBrokersTests",
+            dependencies: ["AthenaBrokers", "AthenaCore"]
+        ),
+        .testTarget(
+            name: "AthenaDataTests",
+            dependencies: ["AthenaData", "AthenaCore"]
+        ),
+        .testTarget(
+            name: "AthenaBacktestTests",
+            dependencies: [
+                "AthenaBacktest", "AthenaCore", "AthenaIndicators",
+                "AthenaBrokers", "AthenaData",
+            ]
+        ),
+        .testTarget(
+            name: "AthenaSweepTests",
+            dependencies: [
+                "AthenaSweep", "AthenaCore", "AthenaIndicators",
+                "AthenaBrokers", "AthenaData", "AthenaBacktest",
+            ]
+        ),
+        .testTarget(
+            name: "AthenaMLXTests",
+            dependencies: [
+                "AthenaMLX", "AthenaSweep", "AthenaCore",
+                "AthenaBacktest",
+            ]
+        ),
     ]
 )

--- a/Sources/AthenaCore/VectorizableStrategy.swift
+++ b/Sources/AthenaCore/VectorizableStrategy.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // MARK: - VectorizableStrategy
 
 /// An opt-in protocol for strategies that can express their signal logic
@@ -19,6 +17,10 @@ import Foundation
 /// - Each element is `true` (long — fully in) or `false` (flat — fully out).
 /// - A transition from `false → true` triggers a **buy at the next bar's open**.
 /// - A transition from `true → false` triggers a **sell at the next bar's open**.
+/// - A transition signalled on the **final bar** has no next open and is
+///   therefore **not filled** — the position is left unchanged for the
+///   remainder of the run. Any open position is marked-to-market at the
+///   final bar's close but never liquidated by an implicit trade.
 /// - The ``Strategy`` methods (``onStart``, ``onBar``, ``onFinish``) remain
 ///   fully available for event-driven use; `VectorizableStrategy` only adds
 ///   the `signals(for:)` method.
@@ -43,6 +45,7 @@ public protocol VectorizableStrategy: Strategy {
     ///   is the same `bars` that was passed to the ``Sweep``.
     /// - Returns: A `Bool` array whose length equals `bars.count`. `true`
     ///   means "long"; `false` means "flat". A change between adjacent
-    ///   elements triggers a fill at the **next** bar's open.
+    ///   elements triggers a fill at the **next** bar's open. A change
+    ///   signalled on the final bar has no next open and is not filled.
     func signals(for bars: [Bar]) -> [Bool]
 }

--- a/Sources/AthenaCore/VectorizableStrategy.swift
+++ b/Sources/AthenaCore/VectorizableStrategy.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+// MARK: - VectorizableStrategy
+
+/// An opt-in protocol for strategies that can express their signal logic
+/// as a single vectorized pass over a bar array.
+///
+/// Strategies that conform to `VectorizableStrategy` are eligible for the
+/// `MLXBacktestRunner` fast path in `AthenaMLX`. Non-conforming strategies
+/// are silently routed to `EventDrivenRunner` on a per-cell basis — callers
+/// never need to handle the dispatch themselves.
+///
+/// ## v0.5 scope
+/// Long-only / flat positions only. Short positions, sized positions,
+/// leverage, and multi-symbol signal dependencies are out of scope.
+///
+/// ## Implementation contract
+/// - ``signals(for:)`` must return an array of the **same length** as `bars`.
+/// - Each element is `true` (long — fully in) or `false` (flat — fully out).
+/// - A transition from `false → true` triggers a **buy at the next bar's open**.
+/// - A transition from `true → false` triggers a **sell at the next bar's open**.
+/// - The ``Strategy`` methods (``onStart``, ``onBar``, ``onFinish``) remain
+///   fully available for event-driven use; `VectorizableStrategy` only adds
+///   the `signals(for:)` method.
+///
+/// ## Example
+/// ```swift
+/// struct SMACrossover: Strategy, VectorizableStrategy {
+///     let fast: Int
+///     let slow: Int
+///
+///     func onBar(_ bar: Bar, context: StrategyContext) async throws { ... }
+///
+///     func signals(for bars: [Bar]) -> [Bool] {
+///         // compute SMA vectors and return long/flat signal per bar
+///     }
+/// }
+/// ```
+public protocol VectorizableStrategy: Strategy {
+    /// Compute a position signal for every bar in `bars` in a single pass.
+    ///
+    /// - Parameter bars: The full bar sequence for the backtest. The array
+    ///   is the same `bars` that was passed to the ``Sweep``.
+    /// - Returns: A `Bool` array whose length equals `bars.count`. `true`
+    ///   means "long"; `false` means "flat". A change between adjacent
+    ///   elements triggers a fill at the **next** bar's open.
+    func signals(for bars: [Bar]) -> [Bool]
+}

--- a/Sources/AthenaMLX/MLXBacktestRunner.swift
+++ b/Sources/AthenaMLX/MLXBacktestRunner.swift
@@ -1,0 +1,58 @@
+import AthenaCore
+import AthenaBacktest
+import AthenaSweep
+
+// MARK: - MLXBacktestRunner
+
+/// A ``BacktestRunner`` with an MLX-backed fast path for vectorizable
+/// strategies on Apple Silicon (macOS / iOS).
+///
+/// **Fast-path eligibility (later v0.5 slices):**
+/// - The strategy must conform to ``VectorizableStrategy``.
+/// - The ``BacktestConfig`` must use ``NoTaxes`` (tax-regime vectorization
+///   is out of scope for v0.5).
+///
+/// When neither condition is met the runner transparently falls back to
+/// ``EventDrivenRunner`` per cell, so callers never need to handle the
+/// dispatch themselves.
+///
+/// **v0.5 slice 1 (this file):** the seam is in place — `MLXBacktestRunner`
+/// fully conforms to ``BacktestRunner`` — but the tensor dispatch is
+/// delegated to ``EventDrivenRunner`` until later slices add real MLX work.
+/// Switching to `MLXBacktestRunner` today is safe and produces identical
+/// results to the event-driven path.
+///
+/// ## Usage
+/// ```swift
+/// let sweep = Sweep(
+///     factory: factory,
+///     runner: MLXBacktestRunner(),  // ← only new line vs v0.4
+///     bars: bars,
+///     config: config,
+///     space: space
+/// )
+/// ```
+public struct MLXBacktestRunner: BacktestRunner {
+
+    public init() {}
+
+    // MARK: BacktestRunner
+
+    /// Run one backtest cell.
+    ///
+    /// **Slice 1 behaviour:** always delegates to ``EventDrivenRunner``.
+    /// Later slices will inspect `strategy` for ``VectorizableStrategy``
+    /// conformance and `config.taxRegime` for ``NoTaxes``; if both
+    /// conditions are met, real MLX tensor dispatch is used instead.
+    public func run(
+        strategy: any Strategy,
+        bars: [Bar],
+        config: BacktestConfig
+    ) async throws -> BacktestResult {
+        return try await EventDrivenRunner().run(
+            strategy: strategy,
+            bars: bars,
+            config: config
+        )
+    }
+}

--- a/Tests/AthenaMLXTests/MLXBacktestRunnerTests.swift
+++ b/Tests/AthenaMLXTests/MLXBacktestRunnerTests.swift
@@ -84,7 +84,8 @@ final class MLXRunnerConformanceTests: XCTestCase {
     /// This verifies the seam contract is fully satisfied.
     func test_mlxRunner_conformsToBacktestRunnerProtocol() {
         let runner: any BacktestRunner = MLXBacktestRunner()
-        XCTAssertNotNil(runner)
+        XCTAssertTrue(runner is MLXBacktestRunner,
+                      "Existential must preserve the concrete MLXBacktestRunner type")
     }
 
     /// `MLXBacktestRunner` can be passed to `Sweep.init(runner:)`.
@@ -120,6 +121,7 @@ final class MLXRunnerConformanceTests: XCTestCase {
 final class MLXRunnerSingleCellTests: XCTestCase {
 
     /// A bare `run(strategy:bars:config:)` call returns a valid result.
+    /// `NopStrategy` trades nothing, so the run must produce zero fills.
     func test_singleRun_returnsBacktestResult() async throws {
         let bars = makeBars(5)
         let config = makeConfig(bars: bars)
@@ -128,7 +130,8 @@ final class MLXRunnerSingleCellTests: XCTestCase {
             bars: bars,
             config: config
         )
-        XCTAssertNotNil(result)
+        XCTAssertTrue(result.fills.isEmpty,
+                      "NopStrategy must produce zero fills")
     }
 
     /// The result's initial equity matches the config's `initialCash`.
@@ -144,7 +147,8 @@ final class MLXRunnerSingleCellTests: XCTestCase {
                        "Initial equity must match the config's initialCash")
     }
 
-    /// Running with empty bars returns a result without crashing.
+    /// Running with empty bars returns an empty-shaped result without crashing:
+    /// no snapshots, no fills, and equity unchanged from the initial cash.
     func test_singleRun_handlesEmptyBars() async throws {
         let config = BacktestConfig(
             startDate: Date(timeIntervalSince1970: 0),
@@ -156,7 +160,10 @@ final class MLXRunnerSingleCellTests: XCTestCase {
             bars: [],
             config: config
         )
-        XCTAssertNotNil(result)
+        XCTAssertTrue(result.snapshots.isEmpty, "Empty bars must produce no snapshots")
+        XCTAssertTrue(result.fills.isEmpty, "Empty bars must produce no fills")
+        XCTAssertEqual(result.finalEquity, config.initialCash,
+                       "Equity must stay at the initial cash level for an empty run")
     }
 }
 
@@ -244,13 +251,17 @@ final class VectorizableStrategyTests: XCTestCase {
     /// A type conforming to `VectorizableStrategy` also satisfies `Strategy`.
     func test_vectorizableStrategy_conformingTypeAlsoConformsToStrategy() {
         let strategy: any Strategy = AlwaysLongStrategy(symbol: Symbol("T"))
-        XCTAssertNotNil(strategy)
+        XCTAssertTrue(strategy is any VectorizableStrategy,
+                      "Upcast to Strategy must preserve VectorizableStrategy conformance")
     }
 
-    /// A `VectorizableStrategy` can be stored as `any VectorizableStrategy`.
+    /// A `VectorizableStrategy` can be stored as `any VectorizableStrategy`
+    /// and its `signals(for:)` dispatches correctly through the existential.
     func test_vectorizableStrategy_canBeStoredAsProtocolExistential() {
         let strategy: any VectorizableStrategy = AlwaysLongStrategy(symbol: Symbol("T"))
-        XCTAssertNotNil(strategy)
+        let bars = makeBars(4)
+        XCTAssertEqual(strategy.signals(for: bars), [true, true, true, true],
+                       "signals(for:) must dispatch through the existential")
     }
 
     /// `signals(for:)` returns an array of the same length as the bar input.

--- a/Tests/AthenaMLXTests/MLXBacktestRunnerTests.swift
+++ b/Tests/AthenaMLXTests/MLXBacktestRunnerTests.swift
@@ -1,0 +1,286 @@
+import XCTest
+import AthenaCore
+import AthenaBacktest
+import AthenaSweep
+@testable import AthenaMLX
+
+// MARK: - Private fixtures
+
+/// A strategy that does nothing — holds all cash through the run.
+private struct NopStrategy: Strategy {
+    func onBar(_ bar: Bar, context: StrategyContext) async throws {}
+}
+
+/// An actor-based once-flag so `BuyOnceStrategy` stays `Sendable`.
+private actor _OnceFlag {
+    private(set) var isSet = false
+    func set() { isSet = true }
+}
+
+/// A strategy that buys `qty` shares on the first matching bar and holds.
+private struct BuyOnceStrategy: Strategy {
+    let symbol: Symbol
+    let qty: Decimal
+    private let flag = _OnceFlag()
+
+    func onBar(_ bar: Bar, context: StrategyContext) async throws {
+        guard bar.symbol == symbol else { return }
+        if await flag.isSet { return }
+        await flag.set()
+        _ = try? await context.buy(symbol, quantity: qty)
+    }
+}
+
+/// A minimal `VectorizableStrategy` that is always long.
+private struct AlwaysLongStrategy: Strategy, VectorizableStrategy {
+    let symbol: Symbol
+    func onBar(_ bar: Bar, context: StrategyContext) async throws {}
+    func signals(for bars: [Bar]) -> [Bool] { bars.map { _ in true } }
+}
+
+/// A minimal `VectorizableStrategy` that is always flat.
+private struct AlwaysFlatStrategy: Strategy, VectorizableStrategy {
+    let symbol: Symbol
+    func onBar(_ bar: Bar, context: StrategyContext) async throws {}
+    func signals(for bars: [Bar]) -> [Bool] { bars.map { _ in false } }
+}
+
+// MARK: - Helpers
+
+private func makeBars(
+    _ n: Int,
+    symbol: Symbol = Symbol("T"),
+    startYear: Int = 2024
+) -> [Bar] {
+    let start = Calendar(identifier: .gregorian)
+        .date(from: DateComponents(year: startYear, month: 1, day: 1))!
+    return (0..<n).map { i in
+        let price = Decimal(100 + i)
+        return Bar(
+            symbol: symbol,
+            timestamp: start.addingTimeInterval(Double(i) * 86_400),
+            open: price,
+            high: price + 1,
+            low: price - 1,
+            close: price,
+            volume: 1_000_000
+        )
+    }
+}
+
+private func makeConfig(bars: [Bar]) -> BacktestConfig {
+    BacktestConfig(
+        startDate: bars.first!.timestamp,
+        endDate: bars.last!.timestamp,
+        initialCash: .usd(10_000)
+    )
+}
+
+// MARK: - Protocol-conformance tests
+
+final class MLXRunnerConformanceTests: XCTestCase {
+
+    /// `MLXBacktestRunner` can be assigned to `any BacktestRunner`.
+    /// This verifies the seam contract is fully satisfied.
+    func test_mlxRunner_conformsToBacktestRunnerProtocol() {
+        let runner: any BacktestRunner = MLXBacktestRunner()
+        XCTAssertNotNil(runner)
+    }
+
+    /// `MLXBacktestRunner` can be passed to `Sweep.init(runner:)`.
+    func test_mlxRunner_canBeUsedAsSweepRunner() async {
+        let sym = Symbol("T")
+        let bars = makeBars(5, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let space = ParameterSpace.grid([.ints("qty", [1])])
+        let sym2 = sym  // capture for @Sendable closure
+        let factory = ClosureStrategyFactory { params -> any Strategy in
+            BuyOnceStrategy(symbol: sym2, qty: Decimal(params.int("qty") ?? 1))
+        }
+        let sweep = Sweep(
+            factory: factory,
+            runner: MLXBacktestRunner(),
+            bars: bars,
+            config: config,
+            space: space
+        )
+        let results = await sweep.run()
+        XCTAssertEqual(results.count, 1,
+                       "Sweep with MLXRunner should return one result per parameter set")
+    }
+
+    /// `MLXBacktestRunner()` initialises without parameters.
+    func test_mlxRunner_hasPublicZeroArgInit() {
+        _ = MLXBacktestRunner()  // must compile and not trap
+    }
+}
+
+// MARK: - Single-cell execution tests
+
+final class MLXRunnerSingleCellTests: XCTestCase {
+
+    /// A bare `run(strategy:bars:config:)` call returns a valid result.
+    func test_singleRun_returnsBacktestResult() async throws {
+        let bars = makeBars(5)
+        let config = makeConfig(bars: bars)
+        let result = try await MLXBacktestRunner().run(
+            strategy: NopStrategy(),
+            bars: bars,
+            config: config
+        )
+        XCTAssertNotNil(result)
+    }
+
+    /// The result's initial equity matches the config's `initialCash`.
+    func test_singleRun_resultHasCorrectInitialEquity() async throws {
+        let bars = makeBars(5)
+        let config = makeConfig(bars: bars)
+        let result = try await MLXBacktestRunner().run(
+            strategy: NopStrategy(),
+            bars: bars,
+            config: config
+        )
+        XCTAssertEqual(result.initialEquity, config.initialCash,
+                       "Initial equity must match the config's initialCash")
+    }
+
+    /// Running with empty bars returns a result without crashing.
+    func test_singleRun_handlesEmptyBars() async throws {
+        let config = BacktestConfig(
+            startDate: Date(timeIntervalSince1970: 0),
+            endDate: Date(timeIntervalSince1970: 86_400),
+            initialCash: .usd(10_000)
+        )
+        let result = try await MLXBacktestRunner().run(
+            strategy: NopStrategy(),
+            bars: [],
+            config: config
+        )
+        XCTAssertNotNil(result)
+    }
+}
+
+// MARK: - Result-shape equivalence tests
+
+final class MLXRunnerResultShapeTests: XCTestCase {
+
+    /// Result count from `MLXBacktestRunner` matches `EventDrivenRunner` on
+    /// a grid sweep.
+    func test_gridSweep_mlxAndEventDrivenReturnSameCount() async {
+        let sym = Symbol("T")
+        let bars = makeBars(10, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let space = ParameterSpace.grid([.ints("qty", [1, 5, 10])])
+        let sym2 = sym
+        let factory = ClosureStrategyFactory { params -> any Strategy in
+            BuyOnceStrategy(symbol: sym2, qty: Decimal(params.int("qty") ?? 1))
+        }
+
+        let mlxResults = await Sweep(
+            factory: factory, runner: MLXBacktestRunner(),
+            bars: bars, config: config, space: space
+        ).run()
+        let edResults = await Sweep(
+            factory: factory, runner: EventDrivenRunner(),
+            bars: bars, config: config, space: space
+        ).run()
+
+        XCTAssertEqual(mlxResults.count, edResults.count,
+                       "Both runners must return one SweepResult per parameter set")
+    }
+
+    /// Parameter-set order is preserved through `MLXBacktestRunner`.
+    func test_gridSweep_mlxRunnerPreservesParameterOrder() async {
+        let sym = Symbol("T")
+        let bars = makeBars(10, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let expectedQtys = [1, 2, 3]
+        let space = ParameterSpace.grid([.ints("qty", expectedQtys)])
+        let sym2 = sym
+        let factory = ClosureStrategyFactory { params -> any Strategy in
+            BuyOnceStrategy(symbol: sym2, qty: Decimal(params.int("qty") ?? 1))
+        }
+        let results = await Sweep(
+            factory: factory, runner: MLXBacktestRunner(),
+            bars: bars, config: config, space: space
+        ).run()
+
+        XCTAssertEqual(results.count, expectedQtys.count)
+        for (result, qty) in zip(results, expectedQtys) {
+            XCTAssertEqual(result.params.int("qty"), qty,
+                           "MLXBacktestRunner must preserve the parameter grid order")
+        }
+    }
+
+    /// A per-cell failure does not crash the sweep.
+    func test_gridSweep_mlxRunnerIsolatesPerCellFailure() async {
+        let sym = Symbol("T")
+        let bars = makeBars(3, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let space = ParameterSpace.grid([.ints("x", [0])])
+        // Factory always throws — simulates a bad parameter combination.
+        let factory = ClosureStrategyFactory { _ -> any Strategy in
+            throw NSError(domain: "TestError", code: 42)
+        }
+        let results = await Sweep(
+            factory: factory, runner: MLXBacktestRunner(),
+            bars: bars, config: config, space: space
+        ).run()
+
+        XCTAssertEqual(results.count, 1,
+                       "One result per parameter set even on failure")
+        if case .failure = results[0].outcome {
+            // expected — per-cell failure is isolated
+        } else {
+            XCTFail("Expected a .failure outcome for a throwing factory")
+        }
+    }
+}
+
+// MARK: - VectorizableStrategy tests
+
+final class VectorizableStrategyTests: XCTestCase {
+
+    /// A type conforming to `VectorizableStrategy` also satisfies `Strategy`.
+    func test_vectorizableStrategy_conformingTypeAlsoConformsToStrategy() {
+        let strategy: any Strategy = AlwaysLongStrategy(symbol: Symbol("T"))
+        XCTAssertNotNil(strategy)
+    }
+
+    /// A `VectorizableStrategy` can be stored as `any VectorizableStrategy`.
+    func test_vectorizableStrategy_canBeStoredAsProtocolExistential() {
+        let strategy: any VectorizableStrategy = AlwaysLongStrategy(symbol: Symbol("T"))
+        XCTAssertNotNil(strategy)
+    }
+
+    /// `signals(for:)` returns an array of the same length as the bar input.
+    func test_vectorizableStrategy_signalCountMatchesBarCount() {
+        let bars = makeBars(20)
+        let strategy = AlwaysLongStrategy(symbol: Symbol("T"))
+        XCTAssertEqual(strategy.signals(for: bars).count, bars.count,
+                       "Signal array must have the same length as the bar array")
+    }
+
+    /// `signals(for:)` returns an empty array when given empty input.
+    func test_vectorizableStrategy_emptyBarsProduceEmptySignals() {
+        let strategy = AlwaysLongStrategy(symbol: Symbol("T"))
+        XCTAssertTrue(strategy.signals(for: []).isEmpty,
+                      "Empty bars must produce an empty signal array")
+    }
+
+    /// An always-flat strategy produces all-false signals.
+    func test_vectorizableStrategy_flatStrategyProducesAllFalseSignals() {
+        let bars = makeBars(5)
+        let strategy = AlwaysFlatStrategy(symbol: Symbol("T"))
+        XCTAssertTrue(strategy.signals(for: bars).allSatisfy { !$0 },
+                      "AlwaysFlatStrategy must produce all-false signals")
+    }
+
+    /// An always-long strategy produces all-true signals.
+    func test_vectorizableStrategy_longStrategyProducesAllTrueSignals() {
+        let bars = makeBars(5)
+        let strategy = AlwaysLongStrategy(symbol: Symbol("T"))
+        XCTAssertTrue(strategy.signals(for: bars).allSatisfy { $0 },
+                      "AlwaysLongStrategy must produce all-true signals")
+    }
+}


### PR DESCRIPTION
## Summary

Implements **apl9000/hq#112** — v0.5 slice 1 of 6: scaffold the MLX runner seam.

### What was built

- **`AthenaCore/VectorizableStrategy.swift`** — new opt-in protocol (`VectorizableStrategy: Strategy`) exposing `signals(for: [Bar]) -> [Bool]`. Strategy authors conform when they want the MLX fast path; non-conforming strategies fall back to `EventDrivenRunner` transparently. Long/flat v0.5 scope is documented inline.

- **`AthenaMLX/MLXBacktestRunner.swift`** — new module `AthenaMLX` with `MLXBacktestRunner: BacktestRunner`. This slice delegates entirely to `EventDrivenRunner`; the seam is in place for later slices to replace delegation with real MLX tensor dispatch behind `#if canImport(MLX)` guards. Drop-in usage is a one-line change: `runner: MLXBacktestRunner()`.

- **`AthenaMLXTests/MLXBacktestRunnerTests.swift`** — 13 behaviour-first tests across four test classes:
  - `MLXRunnerConformanceTests` — `BacktestRunner` protocol satisfaction, use as sweep runner, zero-arg init.
  - `MLXRunnerSingleCellTests` — non-nil result, correct initial equity, empty-bar safety.
  - `MLXRunnerResultShapeTests` — count parity vs `EventDrivenRunner`, parameter-order preservation, per-cell failure isolation.
  - `VectorizableStrategyTests` — sub-protocol + existential storage, signal-array length invariant, empty-input guard, always-flat / always-long fixtures.

- **`Package.swift`** — registers `AthenaSweep` and `AthenaMLX` library products and targets (AthenaSweep source + tests existed but were not registered), `ParameterSweepExample` executable, `AthenaSweepTests`, and `AthenaMLXTests` test targets.

### Acceptance criteria

- [x] Existing Athena v0.4 products, examples, and tests continue to build on non-MLX platforms — no changes to any v0.4 module
- [x] `AthenaMLX` library product registered and buildable
- [x] `MLXBacktestRunner` conforms to `BacktestRunner` contract (tested)
- [x] `VectorizableStrategy` available as opt-in protocol in `AthenaCore` (tested)
- [x] A simple sweep using `MLXBacktestRunner` returns the same result shape as `EventDrivenRunner` (tested)

### Validation

Swift is not available in the Linux Circuitry worker. CI runs on `macos-14` / Xcode 15 (`swift build` + `swift test` via `./scripts/coverage.sh`). This PR is intentionally draft until CI confirms green.

### Notes for later slices

- Slice 2 (vectorized indicators) and slice 3 (fill + equity reduction) will add `mlx-swift` as a conditional macOS/iOS dependency in `Package.swift` and replace the `EventDrivenRunner()` delegation in `MLXBacktestRunner.run(_:bars:config:)` with actual tensor dispatch, guarded by `#if canImport(MLX)`.
- The `VectorizableStrategy.signals(for:)` contract and `MLXBacktestRunner`'s public API are intentionally minimal so they don't need to change when the tensor path arrives.

Closes apl9000/hq#112