### PR TITLE
feat(athena): MLX sweep demo example and v0.5 docs [#117]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,97 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - TBD
+
+The "MLX runner seam release". Adds the `AthenaMLX` module with
+`MLXBacktestRunner` — a `BacktestRunner` that is the entry point for
+the MLX-backed vectorized fast path on Apple Silicon. In v0.5 slice 1
+the runner delegates to `EventDrivenRunner` internally, so results are
+numerically identical and the seam builds on every platform. The
+`VectorizableStrategy` opt-in protocol is available for strategies that
+can express their signal logic as a single vectorized pass.
+
+### Added
+
+- **AthenaCore**: `VectorizableStrategy` — opt-in protocol for strategies
+  that can provide a `signals(for:) -> [Bool]` method. `true` = long
+  (fully in); `false` = flat (fully out). Conforming strategies are
+  eligible for the `MLXBacktestRunner` fast path when `BacktestConfig`
+  also uses `NoTaxes`. The `Strategy` event methods remain fully
+  available; `VectorizableStrategy` only adds `signals(for:)`.
+- **AthenaMLX**: New library product. `MLXBacktestRunner` conforming
+  to `BacktestRunner` — a drop-in replacement for `EventDrivenRunner`
+  in any `Sweep.init(runner:)` call. Slice 1 delegates internally to
+  `EventDrivenRunner`; later slices add real MLX tensor dispatch for
+  `VectorizableStrategy + NoTaxes` cells on Apple Silicon.
+- **MLXSweepExample**: Worked example demonstrating the one-line runner
+  swap. Runs the same MA-crossover grid sweep twice — once with
+  `EventDrivenRunner` and once with `MLXBacktestRunner` — printing
+  timing and result tables so users can observe result equivalence on
+  their own hardware.
+
+### Design notes
+
+- **One-line swap.** Adopting `MLXBacktestRunner` requires only changing
+  the `runner:` argument to `Sweep.init`. No strategy changes, no
+  conditional compilation, no platform guards in user code.
+- **Transparent fallback.** Cells that are not fast-path eligible
+  (non-`VectorizableStrategy` or non-`NoTaxes`) are silently routed to
+  `EventDrivenRunner` per cell. The caller never needs to detect or
+  handle the dispatch.
+- **Platform gating.** `MLXBacktestRunner` is available on all platforms.
+  The tensor fast path (later slices) requires Apple Silicon. Non-MLX
+  platforms (Intel macOS, Linux) fall back to `EventDrivenRunner` with
+  identical results and no build errors.
+- **Tax-regime sweeps fall back.** `CanadianACB` and `USWashSale` sweeps
+  always use `EventDrivenRunner` per cell; the vectorized path is for
+  `NoTaxes` only and does not support retroactive reconciliation.
+
+### Known limitations
+
+- MLX tensor dispatch is not yet implemented (slice 1 delegates).
+  Real vectorized performance requires later v0.5 slices.
+- Long-only / flat positions only. Short positions, leverage, and sized
+  positions are out of v0.5 scope.
+- Vectorized indicator coverage: SMA, EMA, RSI, Bollinger Bands only.
+  MACD and ATR fall back to the event-driven path automatically.
+- Multi-symbol strategies are not fast-path eligible in v0.5.
+- Walk-forward helpers and benchmark harnesses are out of v0.5 scope.
+
+## [0.4.0] - TBD
+
+The "parameter sweep release". Adds `AthenaSweep` — parallel parameter
+sweeps over a grid or random sample of strategy configurations.
+
+### Added
+
+- **AthenaSweep**: `BacktestRunner` protocol (abstraction over running
+  one strategy over one set of bars), `EventDrivenRunner` (default
+  implementation wrapping `BacktestEngine`), `StrategyFactory` protocol
+  + `ClosureStrategyFactory`, `ParameterSet` (a single point in
+  parameter space), `AnySendableValue` (type-erased Sendable value),
+  `ParameterAxis` (one named axis with discrete values),
+  `ParameterSpace` (enumerated `ParameterSet`s — `.grid()` for
+  Cartesian products, `.random()` for seeded random sampling),
+  `Sweep` (parallel execution bounded by `concurrency`), `SweepResult`,
+  `SweepError`.
+- **ParameterSweepExample**: Demonstrates a 3×3 MA-crossover grid sweep
+  on 1 000 synthetic daily bars, printing a return/drawdown/Sharpe/fills
+  table and highlighting the best Sharpe combination.
+- **AthenaSweepTests**: `ParameterSpaceTests` (grid, random, empty-axis
+  edge cases) and `SweepTests` (concurrency, ordering, failure isolation).
+
+### Design notes
+
+- **Concurrency-bounded.** `Sweep` dispatches one backtest per
+  `ParameterSet` using a task-group semaphore capped at
+  `ProcessInfo.activeProcessorCount` to prevent memory thrashing on
+  large grids.
+- **Order-preserving.** `Sweep.run()` returns results in the same order
+  as `space.sets` regardless of completion order.
+- **Failure-isolated.** Per-cell errors land in `SweepResult.Outcome.failure`
+  without aborting the rest of the sweep.
+
 ## [0.3.0] - TBD
 
 The "Tax Realism Release". Adds pluggable tax accounting via a

--- a/Examples/MLXSweep/main.swift
+++ b/Examples/MLXSweep/main.swift
@@ -1,0 +1,228 @@
+import Foundation
+import AthenaCore
+import AthenaIndicators
+import AthenaBrokers
+import AthenaData
+import AthenaBacktest
+import AthenaSweep
+import AthenaMLX
+
+/// Demonstrates the v0.5 MLX runner seam.
+///
+/// The same MA-crossover parameter sweep is run twice:
+///   1. With `EventDrivenRunner` (the v0.4 default)
+///   2. With `MLXBacktestRunner` (the v0.5 fast-path entry point)
+///
+/// Both paths produce identical results. The only code change is the
+/// `runner:` argument passed to `Sweep.init` — a true one-line swap.
+///
+/// Run with: `swift run MLXSweepExample`
+///
+/// ## Platform note
+/// `MLXBacktestRunner` is available on all platforms Athena supports.
+/// In v0.5 slice 1 it delegates internally to `EventDrivenRunner`, so
+/// results are numerically identical and timing differences are minimal.
+/// Later slices will add real MLX tensor dispatch on Apple Silicon;
+/// strategies that conform to `VectorizableStrategy` and use `NoTaxes`
+/// will take that fast path automatically, while all others continue to
+/// fall back to the event-driven path per cell — no strategy changes needed.
+
+// MARK: - Helpers
+
+private extension String {
+    func padded(_ n: Int) -> String {
+        count >= n ? self + " " : self + String(repeating: " ", count: n - count)
+    }
+}
+
+private extension Int {
+    func padded(_ n: Int) -> String { String(self).padded(n) }
+}
+
+private func pct(_ d: Decimal) -> String {
+    String(format: "%.2f%%", NSDecimalNumber(decimal: d * 100).doubleValue)
+}
+
+private func printTable(_ results: [SweepResult]) {
+    let line = String(repeating: "─", count: 68)
+    print(line)
+    print("fast  slow  return    drawdown  sharpe  fills")
+    print(line)
+    for r in results {
+        guard let bt = r.backtest else {
+            print("\(r.params) → ERROR")
+            continue
+        }
+        let fast = r.params.int("fast") ?? 0
+        let slow = r.params.int("slow") ?? 0
+        let sharpe = String(format: "%.2f", bt.sharpe)
+        print(
+            "\(fast.padded(5))\(slow.padded(6))"
+            + "\(pct(bt.totalReturn).padded(10))"
+            + "\(pct(bt.maxDrawdown).padded(10))"
+            + "\(sharpe.padded(8))\(bt.fills.count)"
+        )
+    }
+    print(line)
+}
+
+private func bestBySharpe(_ results: [SweepResult]) -> (ParameterSet, BacktestResult)? {
+    results.compactMap { r -> (ParameterSet, BacktestResult)? in
+        guard let bt = r.backtest else { return nil }
+        return (r.params, bt)
+    }.max { $0.1.sharpe < $1.1.sharpe }
+}
+
+// MARK: - Strategy
+
+private struct MACrossover: Strategy {
+    let symbol: Symbol
+    let fast: Int
+    let slow: Int
+
+    func onBar(_ bar: Bar, context: StrategyContext) async throws {
+        guard bar.symbol == symbol else { return }
+        guard
+            let fastMA = await context.indicators.sma(symbol, period: fast),
+            let slowMA = await context.indicators.sma(symbol, period: slow)
+        else { return }
+        let qty = await context.portfolio.position(for: symbol)?.quantity ?? 0
+        if fastMA > slowMA, qty == 0 {
+            _ = try? await context.buy(symbol, quantity: 100)
+        } else if fastMA < slowMA, qty > 0 {
+            _ = try? await context.sell(symbol, quantity: qty)
+        }
+    }
+
+    func onFinish(context: StrategyContext) async throws {
+        if let pos = await context.portfolio.position(for: symbol), pos.quantity > 0 {
+            try await context.sell(symbol, quantity: pos.quantity)
+        }
+    }
+}
+
+// MARK: - Main
+
+@main
+struct MLXSweepExample {
+    static func main() async throws {
+        let symbol = Symbol("SYN")
+
+        // Synthetic noisy uptrend — 1 000 daily bars starting 2020-01-01.
+        var bars: [Bar] = []
+        var rng = Xoshiro256StarStar(seed: 12345)
+        var price: Decimal = 100
+        let start = Calendar(identifier: .gregorian)
+            .date(from: DateComponents(year: 2020, month: 1, day: 1))!
+        for i in 0..<1_000 {
+            let r01 = Double(rng.next() % 10_000) / 10_000.0
+            let noise = Decimal(r01 * 0.04 - 0.02)
+            price = price * (1 + Decimal(string: "0.0005")! + noise)
+            if price < 1 { price = 1 }
+            bars.append(Bar(
+                symbol: symbol,
+                timestamp: start.addingTimeInterval(Double(i) * 86_400),
+                open: price,
+                high: price * Decimal(string: "1.005")!,
+                low: price * Decimal(string: "0.995")!,
+                close: price,
+                volume: 1_000_000
+            ))
+        }
+
+        let config = BacktestConfig(
+            startDate: bars.first!.timestamp,
+            endDate: bars.last!.timestamp,
+            initialCash: .usd(100_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: NoSlippage()
+        )
+
+        let space = ParameterSpace.grid([
+            .ints("fast", [5, 10, 20]),
+            .ints("slow", [50, 100, 200]),
+        ])
+
+        let factory = ClosureStrategyFactory { params -> any Strategy in
+            MACrossover(
+                symbol: symbol,
+                fast: params.int("fast") ?? 10,
+                slow: params.int("slow") ?? 50
+            )
+        }
+
+        print("""
+        Athena v0.5 — MLX sweep demo
+        ─────────────────────────────────────────────────────────────────────
+        Strategy : MA-crossover (fast × slow grid)
+        Grid     : \(space.sets.count) combinations
+        Bars     : \(bars.count) daily bars (synthetic uptrend)
+
+        """)
+
+        // ── Run 1: EventDrivenRunner (v0.4 default) ─────────────────────────
+        print("── EventDrivenRunner ──")
+        let t0ed = Date()
+        let edResults = await Sweep(
+            factory: factory,
+            runner: EventDrivenRunner(),   // ← v0.4 default
+            bars: bars,
+            config: config,
+            space: space
+        ).run()
+        let edTime = Date().timeIntervalSince(t0ed)
+        printTable(edResults)
+        if let best = bestBySharpe(edResults) {
+            print("Best by Sharpe: \(best.0) → \(String(format: "%.2f", best.1.sharpe))")
+        }
+        print(String(format: "Wall-clock: %.3fs\n", edTime))
+
+        // ── Run 2: MLXBacktestRunner (v0.5 fast-path entry point) ───────────
+        print("── MLXBacktestRunner ──")
+        let t0mlx = Date()
+        let mlxResults = await Sweep(
+            factory: factory,
+            runner: MLXBacktestRunner(),   // ← one-line swap
+            bars: bars,
+            config: config,
+            space: space
+        ).run()
+        let mlxTime = Date().timeIntervalSince(t0mlx)
+        printTable(mlxResults)
+        if let best = bestBySharpe(mlxResults) {
+            print("Best by Sharpe: \(best.0) → \(String(format: "%.2f", best.1.sharpe))")
+        }
+        print(String(format: "Wall-clock: %.3fs\n", mlxTime))
+
+        // ── Result comparison ────────────────────────────────────────────────
+        print("── Result comparison ──")
+        var identical = true
+        for (ed, mlx) in zip(edResults, mlxResults) {
+            guard let edBT = ed.backtest, let mlxBT = mlx.backtest else { continue }
+            if edBT.totalReturn != mlxBT.totalReturn || edBT.fills.count != mlxBT.fills.count {
+                identical = false
+                print("  MISMATCH at \(ed.params):")
+                print("    EventDriven: return=\(pct(edBT.totalReturn)) fills=\(edBT.fills.count)")
+                print("    MLX        : return=\(pct(mlxBT.totalReturn)) fills=\(mlxBT.fills.count)")
+            }
+        }
+        if identical {
+            print("  ✓ All \(edResults.count) cells: results identical across both runners.")
+        }
+
+        print("""
+
+        Notes
+        ─────
+        • Switching to MLXBacktestRunner is the only code change (runner: argument).
+        • In v0.5 slice 1, MLXBacktestRunner delegates to EventDrivenRunner internally,
+          so results are numerically identical and timing is comparable.
+        • Later v0.5 slices add real MLX tensor dispatch on Apple Silicon for
+          strategies that conform to VectorizableStrategy and use NoTaxes.
+          Non-qualifying strategies and non-Apple-Silicon hosts always fall back
+          to EventDrivenRunner — no strategy changes needed, no broken builds.
+        • Tax-regime sweeps (non-NoTaxes) fall back to EventDrivenRunner per cell.
+        • Vectorized indicators in v0.5: SMA, EMA, RSI, Bollinger Bands.
+        """)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -116,6 +116,19 @@ let package = Package(
             ],
             path: "Examples/ParameterSweep"
         ),
+        .executableTarget(
+            name: "MLXSweepExample",
+            dependencies: [
+                "AthenaCore",
+                "AthenaIndicators",
+                "AthenaBrokers",
+                "AthenaData",
+                "AthenaBacktest",
+                "AthenaSweep",
+                "AthenaMLX",
+            ],
+            path: "Examples/MLXSweep"
+        ),
 
         // MARK: - Tests
         .testTarget(name: "AthenaCoreTests", dependencies: ["AthenaCore"]),

--- a/README.md
+++ b/README.md
@@ -6,11 +6,20 @@ Athena is an open-source Swift quant library. It works standalone.
 
 ## Status
 
-**v0.3 — tax realism release.** Adds pluggable `TaxRegime` accounting (`CanadianACB` with the superficial-loss rule, `USWashSale` with FIFO + ST/LT classification + wash-sale rule), per-fill tax-lot tracking, per-disposition realized-P&L records, and per-year tax summaries. Builds on v0.2 (stop / stop-limit fills, splits, cash dividends) and the v0.1 foundation (event-driven engine, six indicators, simulated broker with realistic commission/slippage, CSV data source). Existing strategies that don't set `taxRegime` get the `NoTaxes` default and behave identically. CI enforces ≥ 90% line coverage on every push.
+**v0.5 — MLX runner seam.** Adds the `AthenaMLX` module with `MLXBacktestRunner` — an alternative `BacktestRunner` that is the entry point for the MLX-backed vectorized fast path on Apple Silicon. In v0.5 slice 1 the runner delegates to `EventDrivenRunner` internally, so results are numerically identical and non-MLX platforms build cleanly. The `VectorizableStrategy` opt-in protocol is available for strategies that want to express their signal logic as a single vectorized pass; these strategies will take the real tensor fast path in later v0.5 slices. Switching from `EventDrivenRunner` to `MLXBacktestRunner` is a one-line change to `Sweep.init` — no strategy changes needed.
 
-Planned for v0.4+:
+Builds on v0.4 (`AthenaSweep` module with `Sweep`, `ParameterSpace`, `ParameterAxis`, `BacktestRunner`), v0.3 (pluggable `TaxRegime`, `CanadianACB`, `USWashSale`), v0.2 (stop / stop-limit fills, splits, cash dividends), and the v0.1 foundation (event-driven engine, six indicators, simulated broker, CSV data source). CI enforces ≥ 90% line coverage on every push.
 
-- MLX-backed vectorized engine for parameter sweeps
+### v0.5 scope and limitations
+
+- `MLXBacktestRunner` is available on all platforms. The MLX tensor fast path (later slices) requires Apple Silicon (macOS / iOS).
+- Fast-path eligibility (later slices): strategy must conform to `VectorizableStrategy` AND `BacktestConfig` must use `NoTaxes`. Non-qualifying strategies and tax-regime sweeps fall back to `EventDrivenRunner` per cell — transparently, with no API changes.
+- Vectorized indicators in v0.5: SMA, EMA, RSI, Bollinger Bands. MACD and ATR are not vectorized; strategies using them fall back automatically.
+- Long-only / flat positions only. Short positions, sized positions, and leverage are out of v0.5 scope.
+- Tax-regime sweeps (`CanadianACB`, `USWashSale`) always fall back to `EventDrivenRunner`; the vectorized path is for `NoTaxes` only.
+
+Planned for v0.6+:
+
 - IBKR Web API and Alpaca broker adapters
 - Spin-offs, stock dividends, DRIP reinvestment
 - Multi-currency portfolio with FX provider
@@ -38,11 +47,74 @@ swift run BollingerBreakoutExample
 swift run MACDSignalExample
 swift run ProtectiveStopExample
 swift run TaxAwareExample
+swift run ParameterSweepExample  # v0.4: parameter sweep with EventDrivenRunner
+swift run MLXSweepExample        # v0.5: same sweep with both runners side-by-side
 ```
 
 Each example prints initial/final equity, total return, max drawdown,
 annualized Sharpe, and fill count, so you can compare strategies side-by-side
 against the buy-and-hold baseline.
+
+## MLXBacktestRunner — adopting the v0.5 fast path
+
+`MLXBacktestRunner` is a drop-in replacement for `EventDrivenRunner`. The only
+required change is the `runner:` argument to `Sweep.init`:
+
+```swift
+import AthenaMLX
+
+// v0.4: event-driven (default)
+let sweep = Sweep(factory: factory, bars: bars, config: config, space: space)
+
+// v0.5: MLX runner seam — one-line swap, identical results in slice 1
+let sweep = Sweep(
+    factory: factory,
+    runner: MLXBacktestRunner(),  // ← only change
+    bars: bars,
+    config: config,
+    space: space
+)
+```
+
+**Platform gating.** `MLXBacktestRunner` is available on all platforms. The
+MLX tensor fast path (added in later v0.5 slices) requires Apple Silicon.
+On Intel macOS, Linux, and other non-Apple-Silicon platforms the runner
+falls back to `EventDrivenRunner` per cell — no build errors, no strategy
+changes, and results are identical.
+
+**Fallback behaviour.** In v0.5 slice 1 `MLXBacktestRunner` always delegates
+to `EventDrivenRunner`. Later slices add real tensor dispatch for cells that
+meet both conditions:
+1. The strategy conforms to `VectorizableStrategy`.
+2. The `BacktestConfig` uses `NoTaxes` (tax-regime sweeps always fall back).
+
+Cells that fail either condition are silently routed to `EventDrivenRunner`.
+Callers never need to detect or handle the dispatch themselves.
+
+**`VectorizableStrategy` opt-in.** Strategies that want to participate in
+the fast path implement `signals(for:)`:
+
+```swift
+struct SMACrossover: Strategy, VectorizableStrategy {
+    let fast: Int
+    let slow: Int
+
+    func onBar(_ bar: Bar, context: StrategyContext) async throws { ... }
+
+    // Called once per cell; returns a Bool array the same length as bars.
+    // true = long (fully in), false = flat (fully out).
+    // A false→true transition buys at the next bar's open; true→false sells.
+    // A transition on the final bar has no next open and is not filled.
+    func signals(for bars: [Bar]) -> [Bool] {
+        // compute vectorized SMA signals here
+        return bars.map { _ in true }  // placeholder
+    }
+}
+```
+
+**Vectorized indicators (v0.5).** SMA, EMA, RSI, and Bollinger Bands have
+vectorized implementations inside `AthenaMLX`. Strategies using only these
+four indicators are fast-path eligible. MACD and ATR fall back automatically.
 
 ## Development
 
@@ -64,10 +136,15 @@ make build      # swift build -c release
 
 ```
 AthenaCore         Types, Portfolio, Clock, Strategy + Broker/Indicator protocols
+                   + VectorizableStrategy (v0.5 opt-in for MLX fast path)
 AthenaIndicators   SMA, EMA, RSI, MACD, Bollinger Bands, ATR + IndicatorCache
 AthenaBrokers      Commission/slippage models, SimulatedBroker
 AthenaData         DataSource protocol, CSV reader
 AthenaBacktest     Event-driven engine, results, metrics
+AthenaSweep        Parallel parameter sweeps — BacktestRunner seam, Sweep,
+                   ParameterSpace, ParameterAxis, EventDrivenRunner (v0.4+)
+AthenaMLX          MLXBacktestRunner — fast-path entry point for Apple Silicon
+                   parameter sweeps; falls back to EventDrivenRunner (v0.5+)
 ```
 
 Each module is a separate library product so downstream code imports only what it needs.

--- a/Tests/AthenaMLXTests/MLXRunnerValueEquivalenceTests.swift
+++ b/Tests/AthenaMLXTests/MLXRunnerValueEquivalenceTests.swift
@@ -1,0 +1,232 @@
+import XCTest
+import AthenaCore
+import AthenaBacktest
+import AthenaSweep
+@testable import AthenaMLX
+
+// MARK: - Fixtures
+
+/// A deterministic MA-crossover strategy used as a representative
+/// real-world strategy for equivalence checks. Identical to the
+/// MLXSweepExample's factory output for a given (fast, slow) pair.
+private struct MACrossoverFixture: Strategy {
+    let symbol: Symbol
+    let fast: Int
+    let slow: Int
+
+    func onBar(_ bar: Bar, context: StrategyContext) async throws {
+        guard bar.symbol == symbol else { return }
+        guard
+            let fastMA = await context.indicators.sma(symbol, period: fast),
+            let slowMA = await context.indicators.sma(symbol, period: slow)
+        else { return }
+        let qty = await context.portfolio.position(for: symbol)?.quantity ?? 0
+        if fastMA > slowMA, qty == 0 {
+            _ = try? await context.buy(symbol, quantity: 100)
+        } else if fastMA < slowMA, qty > 0 {
+            _ = try? await context.sell(symbol, quantity: qty)
+        }
+    }
+
+    func onFinish(context: StrategyContext) async throws {
+        if let pos = await context.portfolio.position(for: symbol), pos.quantity > 0 {
+            try await context.sell(symbol, quantity: pos.quantity)
+        }
+    }
+}
+
+private func makeNoisyBars(
+    _ n: Int,
+    symbol: Symbol,
+    seed: UInt64 = 42
+) -> [Bar] {
+    let start = Calendar(identifier: .gregorian)
+        .date(from: DateComponents(year: 2020, month: 1, day: 1))!
+    var rng = Xoshiro256StarStar(seed: seed)
+    var price: Decimal = 100
+    return (0..<n).map { i in
+        let r01 = Double(rng.next() % 10_000) / 10_000.0
+        let noise = Decimal(r01 * 0.04 - 0.02)
+        price = price * (1 + Decimal(string: "0.0005")! + noise)
+        if price < 1 { price = 1 }
+        return Bar(
+            symbol: symbol,
+            timestamp: start.addingTimeInterval(Double(i) * 86_400),
+            open: price, high: price * Decimal(string: "1.005")!,
+            low: price * Decimal(string: "0.995")!, close: price,
+            volume: 1_000_000
+        )
+    }
+}
+
+private func makeConfig(bars: [Bar]) -> BacktestConfig {
+    BacktestConfig(
+        startDate: bars.first!.timestamp,
+        endDate: bars.last!.timestamp,
+        initialCash: .usd(100_000)
+    )
+}
+
+// MARK: - Value equivalence tests
+
+/// Verifies that `MLXBacktestRunner` and `EventDrivenRunner` produce
+/// numerically identical results for the same strategy, bars, and config.
+///
+/// These are the behaviour assertions that underpin the MLXSweepExample's
+/// claim that switching runners is a one-line change that produces the
+/// same results as the event-driven path.
+final class MLXRunnerValueEquivalenceTests: XCTestCase {
+
+    // MARK: Single-cell value equality
+
+    /// `MLXBacktestRunner` and `EventDrivenRunner` must produce the same
+    /// `totalReturn` for a buy-and-hold strategy on identical input.
+    func test_singleCell_totalReturnMatchesEventDriven() async throws {
+        let sym = Symbol("SYN")
+        let bars = makeNoisyBars(200, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let strategy = MACrossoverFixture(symbol: sym, fast: 10, slow: 50)
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.totalReturn, edResult.totalReturn,
+            "totalReturn must be identical across both runners"
+        )
+    }
+
+    /// `maxDrawdown` must match between both runners.
+    func test_singleCell_maxDrawdownMatchesEventDriven() async throws {
+        let sym = Symbol("SYN")
+        let bars = makeNoisyBars(200, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let strategy = MACrossoverFixture(symbol: sym, fast: 10, slow: 50)
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.maxDrawdown, edResult.maxDrawdown,
+            "maxDrawdown must be identical across both runners"
+        )
+    }
+
+    /// Fill count must match: the same trades must be executed regardless
+    /// of which runner is used (in the v0.5 delegation model).
+    func test_singleCell_fillCountMatchesEventDriven() async throws {
+        let sym = Symbol("SYN")
+        let bars = makeNoisyBars(200, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let strategy = MACrossoverFixture(symbol: sym, fast: 10, slow: 50)
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.fills.count, edResult.fills.count,
+            "Fill count must be identical across both runners"
+        )
+    }
+
+    /// `finalEquity` must match: the same terminal portfolio value.
+    func test_singleCell_finalEquityMatchesEventDriven() async throws {
+        let sym = Symbol("SYN")
+        let bars = makeNoisyBars(200, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let strategy = MACrossoverFixture(symbol: sym, fast: 10, slow: 50)
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.finalEquity, edResult.finalEquity,
+            "finalEquity must be identical across both runners"
+        )
+    }
+
+    // MARK: Sweep-level value equality
+
+    /// Every cell in a grid sweep must produce the same `totalReturn`
+    /// from `MLXBacktestRunner` and `EventDrivenRunner`.
+    func test_gridSweep_allCellsTotalReturnMatchEventDriven() async {
+        let sym = Symbol("SYN")
+        let bars = makeNoisyBars(500, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let space = ParameterSpace.grid([
+            .ints("fast", [5, 10, 20]),
+            .ints("slow", [50, 100]),
+        ])
+        let sym2 = sym
+        let factory = ClosureStrategyFactory { params -> any Strategy in
+            MACrossoverFixture(
+                symbol: sym2,
+                fast: params.int("fast") ?? 10,
+                slow: params.int("slow") ?? 50
+            )
+        }
+
+        let mlxResults = await Sweep(
+            factory: factory, runner: MLXBacktestRunner(),
+            bars: bars, config: config, space: space
+        ).run()
+        let edResults = await Sweep(
+            factory: factory, runner: EventDrivenRunner(),
+            bars: bars, config: config, space: space
+        ).run()
+
+        XCTAssertEqual(mlxResults.count, edResults.count,
+                       "Sweep must return the same number of results")
+
+        for (mlx, ed) in zip(mlxResults, edResults) {
+            guard let mlxBT = mlx.backtest, let edBT = ed.backtest else {
+                XCTFail("Expected .success outcomes for params \(mlx.params)")
+                continue
+            }
+            XCTAssertEqual(
+                mlxBT.totalReturn, edBT.totalReturn,
+                "totalReturn must match for params \(mlx.params)"
+            )
+            XCTAssertEqual(
+                mlxBT.fills.count, edBT.fills.count,
+                "fills.count must match for params \(mlx.params)"
+            )
+        }
+    }
+
+    // MARK: Non-vectorizable strategy falls back
+
+    /// A strategy that does NOT conform to `VectorizableStrategy` still
+    /// produces a valid result when run through `MLXBacktestRunner`.
+    /// This confirms the fallback path works for every strategy type.
+    func test_nonVectorizableStrategy_stillProducesValidResult() async throws {
+        // MACrossoverFixture only conforms to Strategy (not VectorizableStrategy).
+        let sym = Symbol("T")
+        let bars = makeNoisyBars(100, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let strategy = MACrossoverFixture(symbol: sym, fast: 5, slow: 20)
+
+        let result = try await MLXBacktestRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+
+        XCTAssertEqual(result.initialEquity, config.initialCash,
+                       "Non-vectorizable strategy must return initialEquity matching config")
+    }
+}


### PR DESCRIPTION
## Summary

Closes apl9000/hq#117.

- **MLXSweepExample** — new executable that runs the same MA-crossover grid sweep through `EventDrivenRunner` and `MLXBacktestRunner` side-by-side, printing timing and result tables and confirming all cells are identical. Demonstrates the one-line runner swap.
- **`MLXRunnerValueEquivalenceTests`** — new test class with six value-level assertions: `totalReturn`, `maxDrawdown`, `finalEquity`, fill count, and whole-grid cell equivalence across both runners; plus a fallback test for non-`VectorizableStrategy` strategies.
- **README** — documents `MLXBacktestRunner` adoption (one-line swap, platform gating, fallback behaviour, `VectorizableStrategy` opt-in, vectorized indicator coverage, v0.5 scope).
- **CHANGELOG** — adds v0.4 (`AthenaSweep`) and v0.5 (`AthenaMLX` seam) entries with design notes, scope, and known limitations.

## Acceptance criteria checklist

- [x] A worked MLX sweep example demonstrates the same parameter sweep with `EventDrivenRunner` and `MLXBacktestRunner`.
- [x] The example prints timing and result tables for both runners so a user can compare without extra tooling.
- [x] README documents how to adopt `MLXBacktestRunner` and what platforms support it.
- [x] Documentation lists vectorized indicators (SMA, EMA, RSI, Bollinger Bands) and states non-vectorizable strategies and tax-regime sweeps fall back to `EventDrivenRunner`.
- [x] Release notes (CHANGELOG) summarise v0.5 behaviour, limitations, and validation expectations.
- [x] Non-MLX platforms build cleanly — `MLXBacktestRunner` is always available; no `#if canImport(MLX)` guards needed in user code or the example.

## Test plan

- [ ] `swift build` — all targets including `MLXSweepExample` compile cleanly.
- [ ] `swift test` — `MLXRunnerValueEquivalenceTests` (6 new tests) and all existing `AthenaMLXTests` pass.
- [ ] `swift run MLXSweepExample` — prints two tables (one per runner) and `✓ All 9 cells: results identical across both runners.`
- [ ] `swift run ParameterSweepExample` — no regression; output unchanged.
- [ ] CI coverage gate ≥ 90% passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)