### PR TITLE
feat(athena): implement MLX fallback paths [#114]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Athena is an open-source Swift quant library. It works standalone.
 
 ## Status
 
-**v0.5 — MLX runner seam.** Adds the `AthenaMLX` module with `MLXBacktestRunner` — an alternative `BacktestRunner` that is the entry point for the MLX-backed vectorized fast path on Apple Silicon. In v0.5 slice 1 the runner delegates to `EventDrivenRunner` internally, so results are numerically identical and non-MLX platforms build cleanly. The `VectorizableStrategy` opt-in protocol is available for strategies that want to express their signal logic as a single vectorized pass; these strategies will take the real tensor fast path in later v0.5 slices. Switching from `EventDrivenRunner` to `MLXBacktestRunner` is a one-line change to `Sweep.init` — no strategy changes needed.
+**v0.5 — MLX runner seam + explicit fallback paths.** Adds the `AthenaMLX` module with `MLXBacktestRunner` — an alternative `BacktestRunner` that is the entry point for the MLX-backed vectorized fast path on Apple Silicon. The runner now contains the explicit dispatch decision: cells that conform to `VectorizableStrategy` _and_ use `NoTaxes` are routed to the fast path; all other cells are transparently forwarded to `EventDrivenRunner`. In the current slice the fast path still delegates to `EventDrivenRunner` so results are numerically identical and non-MLX platforms build cleanly; real tensor dispatch is gated behind `#if canImport(MLX)` and lands in a later slice. The `VectorizableStrategy` opt-in protocol is available for strategies that want to express their signal logic as a single vectorized pass. Switching from `EventDrivenRunner` to `MLXBacktestRunner` is a one-line change to `Sweep.init` — no strategy changes needed.
 
 Builds on v0.4 (`AthenaSweep` module with `Sweep`, `ParameterSpace`, `ParameterAxis`, `BacktestRunner`), v0.3 (pluggable `TaxRegime`, `CanadianACB`, `USWashSale`), v0.2 (stop / stop-limit fills, splits, cash dividends), and the v0.1 foundation (event-driven engine, six indicators, simulated broker, CSV data source). CI enforces ≥ 90% line coverage on every push.
 
@@ -82,14 +82,21 @@ On Intel macOS, Linux, and other non-Apple-Silicon platforms the runner
 falls back to `EventDrivenRunner` per cell — no build errors, no strategy
 changes, and results are identical.
 
-**Fallback behaviour.** In v0.5 slice 1 `MLXBacktestRunner` always delegates
-to `EventDrivenRunner`. Later slices add real tensor dispatch for cells that
-meet both conditions:
+**Fallback behaviour.** `MLXBacktestRunner` evaluates two conditions on every
+cell before deciding the dispatch path:
+
 1. The strategy conforms to `VectorizableStrategy`.
 2. The `BacktestConfig` uses `NoTaxes` (tax-regime sweeps always fall back).
 
-Cells that fail either condition are silently routed to `EventDrivenRunner`.
-Callers never need to detect or handle the dispatch themselves.
+If **either** condition is not met the cell is explicitly routed to
+`EventDrivenRunner`. The result shape and numeric values are identical to a
+direct `EventDrivenRunner` call — the fallback is fully transparent. Callers
+never need to detect or handle the dispatch themselves.
+
+In the current slice the fast-path branch (`VectorizableStrategy` + `NoTaxes`)
+also delegates to `EventDrivenRunner` while real tensor dispatch is pending;
+it is gated behind `#if canImport(MLX)` and will be filled in once `mlx-swift`
+is added as a conditional macOS / iOS dependency.
 
 **`VectorizableStrategy` opt-in.** Strategies that want to participate in
 the fast path implement `signals(for:)`:

--- a/Sources/AthenaMLX/MLXBacktestRunner.swift
+++ b/Sources/AthenaMLX/MLXBacktestRunner.swift
@@ -90,6 +90,8 @@ public struct MLXBacktestRunner: BacktestRunner {
         // Real MLX tensor dispatch is gated here; until mlx-swift is added
         // as a conditional dependency this path also delegates to
         // EventDrivenRunner, keeping non-Apple-Silicon builds green.
+        // Both branches are intentionally identical at this slice — the
+        // #if canImport(MLX) block marks exactly where tensor dispatch lands.
         #if canImport(MLX)
         // TODO: Replace with MLX tensor dispatch in the vectorized-fills slice.
         return try await EventDrivenRunner().run(

--- a/Sources/AthenaMLX/MLXBacktestRunner.swift
+++ b/Sources/AthenaMLX/MLXBacktestRunner.swift
@@ -7,20 +7,31 @@ import AthenaSweep
 /// A ``BacktestRunner`` with an MLX-backed fast path for vectorizable
 /// strategies on Apple Silicon (macOS / iOS).
 ///
-/// **Fast-path eligibility (later v0.5 slices):**
-/// - The strategy must conform to ``VectorizableStrategy``.
-/// - The ``BacktestConfig`` must use ``NoTaxes`` (tax-regime vectorization
-///   is out of scope for v0.5).
+/// ## Fast-path eligibility
+/// Both conditions must be met for a cell to take the MLX fast path:
+/// 1. The strategy conforms to ``VectorizableStrategy``.
+/// 2. The ``BacktestConfig`` uses ``NoTaxes`` (tax-regime vectorization
+///    is out of scope for v0.5).
 ///
-/// When neither condition is met the runner transparently falls back to
-/// ``EventDrivenRunner`` per cell, so callers never need to handle the
-/// dispatch themselves.
+/// ## Fallback behaviour
+/// When either condition is not met, the runner transparently routes
+/// the cell to ``EventDrivenRunner``. Callers never need to detect or
+/// handle the dispatch themselves — the result shape is always the
+/// same ``BacktestResult`` regardless of which path ran.
 ///
-/// **v0.5 slice 1 (this file):** the seam is in place — `MLXBacktestRunner`
-/// fully conforms to ``BacktestRunner`` — but the tensor dispatch is
-/// delegated to ``EventDrivenRunner`` until later slices add real MLX work.
-/// Switching to `MLXBacktestRunner` today is safe and produces identical
-/// results to the event-driven path.
+/// Two explicit fallback triggers:
+/// - **Non-`VectorizableStrategy`**: any strategy that does not implement
+///   ``VectorizableStrategy/signals(for:)`` is routed through
+///   ``EventDrivenRunner`` on a per-cell basis.
+/// - **Non-`NoTaxes` tax regime**: any ``BacktestConfig`` whose
+///   `taxRegime` is not ``NoTaxes`` (e.g. ``USWashSale``,
+///   ``CanadianACB``) always falls back to ``EventDrivenRunner``.
+///
+/// ## v0.5 slice 2 (this file — fallback paths)
+/// Slice 1 established the ``BacktestRunner`` seam. Slice 2 adds the
+/// explicit dispatch decision. The MLX tensor fast path will replace the
+/// `#if canImport(MLX)` placeholder in a later slice once `mlx-swift` is
+/// added as a conditional macOS / iOS dependency.
 ///
 /// ## Usage
 /// ```swift
@@ -38,21 +49,60 @@ public struct MLXBacktestRunner: BacktestRunner {
 
     // MARK: BacktestRunner
 
-    /// Run one backtest cell.
+    /// Run one backtest cell, routing to the MLX fast path when eligible
+    /// or falling back to ``EventDrivenRunner`` otherwise.
     ///
-    /// **Slice 1 behaviour:** always delegates to ``EventDrivenRunner``.
-    /// Later slices will inspect `strategy` for ``VectorizableStrategy``
-    /// conformance and `config.taxRegime` for ``NoTaxes``; if both
-    /// conditions are met, real MLX tensor dispatch is used instead.
+    /// **Dispatch logic:**
+    /// - If `strategy` does not conform to ``VectorizableStrategy`` **or**
+    ///   `config.taxRegime` is not ``NoTaxes``, the call is forwarded to
+    ///   ``EventDrivenRunner`` and the result is returned unchanged.
+    /// - If both conditions are met, the cell is eligible for the MLX
+    ///   tensor fast path. In the current slice that path still delegates
+    ///   to ``EventDrivenRunner``; real tensor dispatch is gated on
+    ///   `#if canImport(MLX)` and lands in a later slice.
+    ///
+    /// Result shape and numeric values are identical across all paths in
+    /// the current slice so that switching runners is a zero-risk change.
     public func run(
         strategy: any Strategy,
         bars: [Bar],
         config: BacktestConfig
     ) async throws -> BacktestResult {
+        // Determine fast-path eligibility.
+        // Both conditions must hold; failing either triggers the explicit fallback.
+        let isVectorizable = strategy is any VectorizableStrategy
+        let isNoTaxes = config.taxRegime is NoTaxes
+
+        guard isVectorizable && isNoTaxes else {
+            // Explicit fallback path:
+            // • Non-VectorizableStrategy: strategy lacks signals(for:).
+            // • Non-NoTaxes regime: tax-regime vectorization is out of v0.5 scope.
+            // Both cases produce results that are numerically identical to a
+            // direct EventDrivenRunner call — the fallback is transparent.
+            return try await EventDrivenRunner().run(
+                strategy: strategy,
+                bars: bars,
+                config: config
+            )
+        }
+
+        // Fast path: VectorizableStrategy + NoTaxes.
+        // Real MLX tensor dispatch is gated here; until mlx-swift is added
+        // as a conditional dependency this path also delegates to
+        // EventDrivenRunner, keeping non-Apple-Silicon builds green.
+        #if canImport(MLX)
+        // TODO: Replace with MLX tensor dispatch in the vectorized-fills slice.
         return try await EventDrivenRunner().run(
             strategy: strategy,
             bars: bars,
             config: config
         )
+        #else
+        return try await EventDrivenRunner().run(
+            strategy: strategy,
+            bars: bars,
+            config: config
+        )
+        #endif
     }
 }

--- a/Tests/AthenaMLXTests/MLXFallbackTests.swift
+++ b/Tests/AthenaMLXTests/MLXFallbackTests.swift
@@ -1,0 +1,494 @@
+import XCTest
+import AthenaCore
+import AthenaBacktest
+import AthenaSweep
+@testable import AthenaMLX
+
+// MARK: - Documented tolerance
+
+/// Maximum acceptable difference when comparing `Sharpe` (a `Double`) between
+/// two runners. Both paths delegate to `EventDrivenRunner` in the current
+/// slice, so results are bit-identical; the tolerance documents the acceptable
+/// bound for future tensor-dispatch implementations.
+private let kSharpeMatchTolerance: Double = 1e-12
+
+// MARK: - Sendable actor flag
+
+/// Sendable once-flag backed by an actor so stateful strategy structs can
+/// satisfy Swift Concurrency's `Sendable` requirement.
+private actor _PurchaseFlag {
+    private(set) var didBuy = false
+    func markBought() { didBuy = true }
+}
+
+// MARK: - Private test fixtures
+
+/// A strategy that does **NOT** conform to `VectorizableStrategy`.
+/// It buys `qty` shares on the first bar it sees and holds.
+/// Its absence of `VectorizableStrategy` conformance guarantees that
+/// `MLXBacktestRunner` will route it through the fallback path.
+private struct NonVectorizableStrategy: Strategy {
+    let symbol: Symbol
+    let qty: Decimal
+    private let flag = _PurchaseFlag()
+
+    func onBar(_ bar: Bar, context: StrategyContext) async throws {
+        guard bar.symbol == symbol else { return }
+        guard await !flag.didBuy else { return }
+        await flag.markBought()
+        _ = try? await context.buy(symbol, quantity: qty)
+    }
+}
+
+/// A strategy that **does** conform to `VectorizableStrategy` and also
+/// buys on the first bar via `onBar`. Used with a non-`NoTaxes` regime
+/// so the tax-regime check, not the strategy check, forces the fallback.
+private struct VectorizableBuyFirstBarStrategy: Strategy, VectorizableStrategy {
+    let symbol: Symbol
+    let qty: Decimal
+    private let flag = _PurchaseFlag()
+
+    func onBar(_ bar: Bar, context: StrategyContext) async throws {
+        guard bar.symbol == symbol else { return }
+        guard await !flag.didBuy else { return }
+        await flag.markBought()
+        _ = try? await context.buy(symbol, quantity: qty)
+    }
+
+    /// Signal: long after the first bar (matches the `onBar` buy semantics
+    /// for fast-path comparison once real MLX dispatch lands).
+    func signals(for bars: [Bar]) -> [Bool] {
+        bars.enumerated().map { (i, _) in i > 0 }
+    }
+}
+
+// MARK: - Bar and config helpers
+
+private func makeLinearBars(
+    _ n: Int,
+    symbol: Symbol = Symbol("T"),
+    startPrice: Int = 100,
+    year: Int = 2024
+) -> [Bar] {
+    let start = Calendar(identifier: .gregorian)
+        .date(from: DateComponents(year: year, month: 1, day: 1))!
+    return (0..<n).map { i in
+        let price = Decimal(startPrice + i)
+        return Bar(
+            symbol: symbol,
+            timestamp: start.addingTimeInterval(Double(i) * 86_400),
+            open: price,
+            high: price + 1,
+            low: price - 1,
+            close: price,
+            volume: 1_000_000
+        )
+    }
+}
+
+private func makeConfig(
+    bars: [Bar],
+    taxRegime: any TaxRegime = NoTaxes()
+) -> BacktestConfig {
+    BacktestConfig(
+        startDate: bars.first!.timestamp,
+        endDate: bars.last!.timestamp,
+        initialCash: .usd(50_000),
+        taxRegime: taxRegime
+    )
+}
+
+// MARK: - Non-VectorizableStrategy fallback tests
+
+/// Verifies that strategies not conforming to `VectorizableStrategy` are
+/// transparently routed to `EventDrivenRunner` by `MLXBacktestRunner`, and
+/// that all five observable metrics are numerically identical to a direct
+/// `EventDrivenRunner` run on the same strategy and bars.
+///
+/// These tests run on all platforms (no MLX required — the fallback is
+/// active everywhere) and remain valid after real MLX tensor dispatch is
+/// added in later slices.
+final class MLXFallbackNonVectorizableTests: XCTestCase {
+
+    /// Total return must be identical when a non-VectorizableStrategy
+    /// falls back to `EventDrivenRunner`.
+    func test_nonVectorizableStrategy_totalReturnMatchesEventDrivenRunner() async throws {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(120, symbol: sym)
+        let config = makeConfig(bars: bars)
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: NonVectorizableStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: NonVectorizableStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.totalReturn, edResult.totalReturn,
+            "totalReturn must be identical: non-VectorizableStrategy falls back to EventDrivenRunner"
+        )
+    }
+
+    /// Max drawdown must be identical when a non-VectorizableStrategy
+    /// falls back to `EventDrivenRunner`.
+    func test_nonVectorizableStrategy_maxDrawdownMatchesEventDrivenRunner() async throws {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(120, symbol: sym)
+        let config = makeConfig(bars: bars)
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: NonVectorizableStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: NonVectorizableStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.maxDrawdown, edResult.maxDrawdown,
+            "maxDrawdown must be identical: non-VectorizableStrategy falls back to EventDrivenRunner"
+        )
+    }
+
+    /// Annualised Sharpe must match within `kSharpeMatchTolerance` when a
+    /// non-VectorizableStrategy falls back to `EventDrivenRunner`.
+    func test_nonVectorizableStrategy_sharpeMatchesEventDrivenRunner() async throws {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(120, symbol: sym)
+        let config = makeConfig(bars: bars)
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: NonVectorizableStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: NonVectorizableStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.sharpe, edResult.sharpe,
+            accuracy: kSharpeMatchTolerance,
+            "Sharpe must match within \(kSharpeMatchTolerance): non-VectorizableStrategy falls back to EventDrivenRunner"
+        )
+    }
+
+    /// Final equity must be identical when a non-VectorizableStrategy
+    /// falls back to `EventDrivenRunner`.
+    func test_nonVectorizableStrategy_finalEquityMatchesEventDrivenRunner() async throws {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(120, symbol: sym)
+        let config = makeConfig(bars: bars)
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: NonVectorizableStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: NonVectorizableStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.finalEquity, edResult.finalEquity,
+            "finalEquity must be identical: non-VectorizableStrategy falls back to EventDrivenRunner"
+        )
+    }
+
+    /// Fill count must be identical when a non-VectorizableStrategy
+    /// falls back to `EventDrivenRunner`.
+    func test_nonVectorizableStrategy_fillCountMatchesEventDrivenRunner() async throws {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(120, symbol: sym)
+        let config = makeConfig(bars: bars)
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: NonVectorizableStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: NonVectorizableStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.fills.count, edResult.fills.count,
+            "fill count must be identical: non-VectorizableStrategy falls back to EventDrivenRunner"
+        )
+        XCTAssertGreaterThan(
+            mlxResult.fills.count, 0,
+            "Fixture must produce at least one fill so the count comparison is non-trivial"
+        )
+    }
+}
+
+// MARK: - Non-NoTaxes tax-regime fallback tests
+
+/// Verifies that any `BacktestConfig` whose `taxRegime` is not `NoTaxes`
+/// forces `MLXBacktestRunner` to fall back to `EventDrivenRunner` per cell —
+/// even when the strategy conforms to `VectorizableStrategy`. The five
+/// observable metrics must be numerically identical to a direct
+/// `EventDrivenRunner` run with the same config.
+///
+/// These tests run on all platforms and remain valid after real MLX tensor
+/// dispatch is added in later slices (the fast path is restricted to
+/// `NoTaxes` configs only).
+final class MLXFallbackTaxRegimeTests: XCTestCase {
+
+    /// Total return must match when a VectorizableStrategy with USWashSale
+    /// falls back to `EventDrivenRunner`.
+    func test_usWashSaleRegime_totalReturnMatchesEventDrivenRunner() async throws {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(120, symbol: sym)
+        let config = makeConfig(bars: bars, taxRegime: USWashSale())
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: VectorizableBuyFirstBarStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: VectorizableBuyFirstBarStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.totalReturn, edResult.totalReturn,
+            "totalReturn must match: USWashSale regime forces fallback to EventDrivenRunner"
+        )
+    }
+
+    /// Max drawdown must match when a VectorizableStrategy with USWashSale
+    /// falls back to `EventDrivenRunner`.
+    func test_usWashSaleRegime_maxDrawdownMatchesEventDrivenRunner() async throws {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(120, symbol: sym)
+        let config = makeConfig(bars: bars, taxRegime: USWashSale())
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: VectorizableBuyFirstBarStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: VectorizableBuyFirstBarStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.maxDrawdown, edResult.maxDrawdown,
+            "maxDrawdown must match: USWashSale regime forces fallback to EventDrivenRunner"
+        )
+    }
+
+    /// Final equity must match when a VectorizableStrategy with USWashSale
+    /// falls back to `EventDrivenRunner`.
+    func test_usWashSaleRegime_finalEquityMatchesEventDrivenRunner() async throws {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(120, symbol: sym)
+        let config = makeConfig(bars: bars, taxRegime: USWashSale())
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: VectorizableBuyFirstBarStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: VectorizableBuyFirstBarStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.finalEquity, edResult.finalEquity,
+            "finalEquity must match: USWashSale regime forces fallback to EventDrivenRunner"
+        )
+    }
+
+    /// Fill count must match when a VectorizableStrategy with USWashSale
+    /// falls back to `EventDrivenRunner`.
+    func test_usWashSaleRegime_fillCountMatchesEventDrivenRunner() async throws {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(120, symbol: sym)
+        let config = makeConfig(bars: bars, taxRegime: USWashSale())
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: VectorizableBuyFirstBarStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: VectorizableBuyFirstBarStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.fills.count, edResult.fills.count,
+            "fill count must match: USWashSale regime forces fallback to EventDrivenRunner"
+        )
+        XCTAssertGreaterThan(
+            mlxResult.fills.count, 0,
+            "Fixture must produce at least one fill so the count comparison is non-trivial"
+        )
+    }
+
+    /// `CanadianACB` regime must also force the fallback path, with results
+    /// matching `EventDrivenRunner` directly.
+    func test_canadianACBRegime_finalEquityMatchesEventDrivenRunner() async throws {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(80, symbol: sym)
+        let config = makeConfig(bars: bars, taxRegime: CanadianACB())
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: VectorizableBuyFirstBarStrategy(symbol: sym, qty: 5),
+            bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: VectorizableBuyFirstBarStrategy(symbol: sym, qty: 5),
+            bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.finalEquity, edResult.finalEquity,
+            "CanadianACB must also force fallback to EventDrivenRunner"
+        )
+    }
+}
+
+// MARK: - Sweep-level fallback ordering and isolation
+
+/// Verifies that `SweepResult` ordering is preserved and per-cell failures
+/// are isolated in both fallback scenarios: non-VectorizableStrategy and
+/// non-NoTaxes regime.
+///
+/// These tests exercise the sweep plumbing in fallback mode and are
+/// platform-agnostic — no MLX availability required.
+final class MLXFallbackSweepTests: XCTestCase {
+
+    /// A grid sweep whose factory produces `NonVectorizableStrategy` cells
+    /// must return results in parameter-grid order.
+    func test_nonVectorizableSweep_preservesParameterOrder() async {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(40, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let expectedQtys = [1, 5, 10, 20]
+        let space = ParameterSpace.grid([.ints("qty", expectedQtys)])
+        let sym2 = sym
+        let factory = ClosureStrategyFactory { params -> any Strategy in
+            NonVectorizableStrategy(symbol: sym2, qty: Decimal(params.int("qty") ?? 1))
+        }
+
+        let results = await Sweep(
+            factory: factory,
+            runner: MLXBacktestRunner(),
+            bars: bars, config: config, space: space
+        ).run()
+
+        XCTAssertEqual(results.count, expectedQtys.count,
+                       "One result per parameter set")
+        for (result, qty) in zip(results, expectedQtys) {
+            XCTAssertEqual(
+                result.params.int("qty"), qty,
+                "Non-VectorizableStrategy fallback sweep must preserve parameter grid order"
+            )
+        }
+    }
+
+    /// A grid sweep that forces tax-regime fallback (VectorizableStrategy
+    /// with USWashSale config) must return results in parameter-grid order.
+    func test_nonNoTaxesSweep_preservesParameterOrder() async {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(40, symbol: sym)
+        let config = makeConfig(bars: bars, taxRegime: USWashSale())
+        let expectedQtys = [1, 5, 10]
+        let space = ParameterSpace.grid([.ints("qty", expectedQtys)])
+        let sym2 = sym
+        let factory = ClosureStrategyFactory { params -> any Strategy in
+            // VectorizableBuyFirstBarStrategy conforms to VectorizableStrategy;
+            // the USWashSale regime forces the fallback path.
+            VectorizableBuyFirstBarStrategy(symbol: sym2, qty: Decimal(params.int("qty") ?? 1))
+        }
+
+        let results = await Sweep(
+            factory: factory,
+            runner: MLXBacktestRunner(),
+            bars: bars, config: config, space: space
+        ).run()
+
+        XCTAssertEqual(results.count, expectedQtys.count,
+                       "One result per parameter set")
+        for (result, qty) in zip(results, expectedQtys) {
+            XCTAssertEqual(
+                result.params.int("qty"), qty,
+                "Tax-regime fallback sweep must preserve parameter grid order"
+            )
+        }
+    }
+
+    /// A failing cell in a non-VectorizableStrategy sweep must not poison
+    /// adjacent cells. The failing cell produces `.failure`; the other cells
+    /// produce `.success`.
+    func test_nonVectorizableSweep_isolatesPerCellFailures() async {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(10, symbol: sym)
+        let config = makeConfig(bars: bars)
+        // Three cells: first succeeds, second fails at factory, third succeeds.
+        let space = ParameterSpace.grid([.ints("x", [1, -1, 2])])
+        let sym2 = sym
+        let factory = ClosureStrategyFactory { params -> any Strategy in
+            let x = params.int("x") ?? 0
+            guard x > 0 else {
+                throw NSError(domain: "TestFallbackError", code: x,
+                              userInfo: [NSLocalizedDescriptionKey: "invalid parameter x=\(x)"])
+            }
+            return NonVectorizableStrategy(symbol: sym2, qty: Decimal(x))
+        }
+
+        let results = await Sweep(
+            factory: factory,
+            runner: MLXBacktestRunner(),
+            bars: bars, config: config, space: space
+        ).run()
+
+        XCTAssertEqual(results.count, 3,
+                       "All three cells must be reported even when one fails")
+        if case .success = results[0].outcome { /* expected */ }
+        else { XCTFail("Cell 0 (x=1) must succeed in non-VectorizableStrategy fallback") }
+        if case .failure = results[1].outcome { /* expected */ }
+        else { XCTFail("Cell 1 (x=-1) must fail with an isolated error") }
+        if case .success = results[2].outcome { /* expected */ }
+        else { XCTFail("Cell 2 (x=2) must succeed in non-VectorizableStrategy fallback") }
+    }
+
+    /// A failing cell in a tax-regime fallback sweep must not poison
+    /// adjacent cells.
+    func test_taxRegimeSweep_isolatesPerCellFailures() async {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(10, symbol: sym)
+        let config = makeConfig(bars: bars, taxRegime: USWashSale())
+        let space = ParameterSpace.grid([.ints("x", [1, -1, 2])])
+        let sym2 = sym
+        let factory = ClosureStrategyFactory { params -> any Strategy in
+            let x = params.int("x") ?? 0
+            guard x > 0 else {
+                throw NSError(domain: "TestFallbackError", code: x,
+                              userInfo: [NSLocalizedDescriptionKey: "invalid parameter x=\(x)"])
+            }
+            return VectorizableBuyFirstBarStrategy(symbol: sym2, qty: Decimal(x))
+        }
+
+        let results = await Sweep(
+            factory: factory,
+            runner: MLXBacktestRunner(),
+            bars: bars, config: config, space: space
+        ).run()
+
+        XCTAssertEqual(results.count, 3,
+                       "All three cells must be reported even when one fails")
+        if case .success = results[0].outcome { /* expected */ }
+        else { XCTFail("Cell 0 (x=1) must succeed in tax-regime fallback") }
+        if case .failure = results[1].outcome { /* expected */ }
+        else { XCTFail("Cell 1 (x=-1) must fail with an isolated error") }
+        if case .success = results[2].outcome { /* expected */ }
+        else { XCTFail("Cell 2 (x=2) must succeed in tax-regime fallback") }
+    }
+}

--- a/Tests/AthenaMLXTests/MLXFallbackTests.swift
+++ b/Tests/AthenaMLXTests/MLXFallbackTests.swift
@@ -10,6 +10,9 @@ import AthenaSweep
 /// two runners. Both paths delegate to `EventDrivenRunner` in the current
 /// slice, so results are bit-identical; the tolerance documents the acceptable
 /// bound for future tensor-dispatch implementations.
+///
+/// NOTE: Once real MLX tensor dispatch is active, accumulated Float16/Float32
+/// rounding will likely require relaxing this constant (suggested: 1e-6).
 private let kSharpeMatchTolerance: Double = 1e-12
 
 // MARK: - Sendable actor flag
@@ -328,6 +331,29 @@ final class MLXFallbackTaxRegimeTests: XCTestCase {
         XCTAssertGreaterThan(
             mlxResult.fills.count, 0,
             "Fixture must produce at least one fill so the count comparison is non-trivial"
+        )
+    }
+
+    /// Sharpe must match when a VectorizableStrategy with USWashSale
+    /// falls back to `EventDrivenRunner`.
+    func test_usWashSaleRegime_sharpeMatchesEventDrivenRunner() async throws {
+        let sym = Symbol("T")
+        let bars = makeLinearBars(120, symbol: sym)
+        let config = makeConfig(bars: bars, taxRegime: USWashSale())
+
+        let mlxResult = try await MLXBacktestRunner().run(
+            strategy: VectorizableBuyFirstBarStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+        let edResult = try await EventDrivenRunner().run(
+            strategy: VectorizableBuyFirstBarStrategy(symbol: sym, qty: 10),
+            bars: bars, config: config
+        )
+
+        XCTAssertEqual(
+            mlxResult.sharpe, edResult.sharpe,
+            accuracy: kSharpeMatchTolerance,
+            "Sharpe must match: USWashSale regime forces fallback to EventDrivenRunner"
         )
     }
 

--- a/Tests/AthenaMLXTests/MLXFallbackTests.swift
+++ b/Tests/AthenaMLXTests/MLXFallbackTests.swift
@@ -58,8 +58,12 @@ private struct VectorizableBuyFirstBarStrategy: Strategy, VectorizableStrategy {
         _ = try? await context.buy(symbol, quantity: qty)
     }
 
-    /// Signal: long after the first bar (matches the `onBar` buy semantics
-    /// for fast-path comparison once real MLX dispatch lands).
+    /// Signal: flat on bar 0, long from bar 1 onward.
+    ///
+    /// The `false → true` transition at index 0→1 triggers a buy at bar 1's
+    /// open (per the `VectorizableStrategy` contract: "a change triggers a fill
+    /// at the **next** bar's open"). This matches `onBar` semantics above, which
+    /// places an order on bar 0 that fills at bar 1's open.
     func signals(for bars: [Bar]) -> [Bool] {
         bars.enumerated().map { (i, _) in i > 0 }
     }


### PR DESCRIPTION
## Summary

Closes apl9000/hq#114.

- **`MLXBacktestRunner`** — adds the explicit dispatch decision to `run()`. The two fallback triggers are now code, not just comments:
  - `strategy is any VectorizableStrategy` → if false, route to `EventDrivenRunner`
  - `config.taxRegime is NoTaxes` → if false, route to `EventDrivenRunner`
  - Both true → fast-path branch (gated on `#if canImport(MLX)`; currently also delegates to `EventDrivenRunner` until `mlx-swift` is added as a conditional dependency in a later slice)
- **`MLXFallbackTests`** — 14 new tests covering all acceptance criteria:
  - `MLXFallbackNonVectorizableTests` (5 tests) — all five observable metrics (totalReturn, maxDrawdown, Sharpe, finalEquity, fillCount) match `EventDrivenRunner` when a strategy does not conform to `VectorizableStrategy`.
  - `MLXFallbackTaxRegimeTests` (5 tests) — same five metrics (four for USWashSale, one for CanadianACB) match `EventDrivenRunner` when `BacktestConfig` uses a non-`NoTaxes` regime, even when the strategy conforms to `VectorizableStrategy`.
  - `MLXFallbackSweepTests` (4 tests) — parameter order preserved and per-cell failures isolated in both fallback scenarios; two ordering tests and two isolation tests.
- **`README.md`** — status section updated to "seam + explicit fallback paths"; Fallback behaviour section expanded to document the two-condition dispatch rule and the `#if canImport(MLX)` placeholder.

## Acceptance criteria

- [x] A strategy that does not conform to `VectorizableStrategy` produces results equal to `EventDrivenRunner` when run through `MLXBacktestRunner` — covered by `MLXFallbackNonVectorizableTests` (5 metric assertions, including a fill-count non-zero guard).
- [x] A configuration with a non-`NoTaxes` tax regime falls back to `EventDrivenRunner` and produces equivalent results — covered by `MLXFallbackTaxRegimeTests` (`USWashSale` and `CanadianACB`).
- [x] Fallback behaviour preserves `SweepResult` ordering and per-cell failure isolation — covered by `MLXFallbackSweepTests` (ordering in both fallback modes; isolation in both fallback modes).
- [x] Fallback tests are gated cleanly when MLX is unavailable, without breaking non-MLX CI — all tests are platform-agnostic (no `#if canImport(MLX)` guard on the test side; the fast-path `#if canImport(MLX)` in `MLXBacktestRunner` keeps non-Apple-Silicon builds green).
- [x] User-facing documentation makes the fallback behaviour explicit — `MLXBacktestRunner` DocC updated; README Fallback behaviour section expanded.

## Test plan

- [ ] `swift build` — all targets compile, 0 warnings introduced.
- [ ] `swift test` — all prior tests pass; 14 new `MLXFallbackTests` pass.
- [ ] `./scripts/coverage.sh` — coverage ≥ 90%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)