### PR TITLE
ci: add Linux job and explicit CD note to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,16 @@
+# CI — Athena
+#
+# Runs swift build + swift test on every pull request and push to main.
+#
+# Platforms:
+#   macOS — full build + test with 90% line-coverage gate (xcrun llvm-cov).
+#   Linux — build + test only; xcrun is macOS-specific so coverage runs
+#           on macOS only.
+#
+# CD: none — Athena is an open-source library / backtest engine with no
+#     deploy target. Do NOT add speculative deploy steps here.
+#     See .github/workflows/release.yml for the tag-based GitHub Release.
+
 name: CI
 
 on:
@@ -10,6 +23,7 @@ env:
   COVERAGE_THRESHOLD: "90.0"
 
 jobs:
+  # ── macOS: build + test + 90% line-coverage gate ─────────────────────────
   build-test-coverage:
     name: Build, Test, Coverage Gate
     runs-on: macos-14
@@ -38,3 +52,22 @@ jobs:
           name: coverage-lcov
           path: coverage.lcov
           if-no-files-found: ignore
+
+  # ── Linux: build + test (no xcrun / coverage tooling) ────────────────────
+  build-test-linux:
+    name: Build & Test (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: swift:5.10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Show toolchain
+        run: swift --version
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test


### PR DESCRIPTION
## Summary

Closes apl9000/hq#182 — CI/CD audit and fix for Athena.

### Audit findings

| Item | Before | After |
|---|---|---|
| `.github/workflows/ci.yml` exists | ✅ yes | — |
| Runs `swift build` + `swift test` | ✅ yes (via `./scripts/coverage.sh`) | — |
| Triggers on `pull_request` → `main` | ✅ yes | — |
| macOS job | ✅ `macos-14` + 90% coverage gate | unchanged |
| Linux job | ❌ missing | ✅ added (`swift:5.10` container, `swift build` + `swift test`) |
| Explicit CD: none comment | ❌ missing | ✅ added in file header |
| Branch protection — check required | ❌ not set | ⚠️ manual step (see below) |

### Changes

- **Added Linux job** (`build-test-linux`) using the official `swift:5.10` container. Runs `swift build` + `swift test`; skips the `xcrun llvm-cov` coverage gate which is macOS-only. The macOS job (`build-test-coverage` / "Build, Test, Coverage Gate") is unchanged so any existing status references stay valid.
- **Added file-header comment** explaining the macOS/Linux split and explicitly marking CD as none — no deploy steps belong here; the tag-based GitHub Release lives in `release.yml`.

### ⚠️ Manual step required — mark check required on main

The agent token does not have `administration` permission on this repo, so branch protection cannot be set programmatically. Once this PR is merged and the checks pass, a repo admin must:

1. **Settings → Branches → Branch protection rules → Add rule**
2. Branch name pattern: `main`
3. ✅ **Require status checks to pass before merging**
4. Search for and add: **`Build, Test, Coverage Gate`** (the macOS job)
5. Optionally also add: **`Build & Test (Linux)`**
6. ✅ **Require branches to be up to date before merging**
7. Save

## Test plan

- [ ] Both CI jobs ("Build, Test, Coverage Gate" and "Build & Test (Linux)") pass on this PR
- [ ] After merge, repo admin enables branch protection per the manual step above
- [ ] A subsequent test PR is blocked from merging until both checks pass

## References

- Workflow file: [`.github/workflows/ci.yml`](https://github.com/apl9000/athena/blob/ci/athena-required-check/.github/workflows/ci.yml)
- Release workflow (CD reference): [`.github/workflows/release.yml`](https://github.com/apl9000/athena/blob/main/.github/workflows/release.yml)
- Issue: apl9000/hq#182

🤖 Generated with [Claude Code](https://claude.com/claude-code)