### PR TITLE
fix: land stranded vectorized-fills work from PR #11 (hq#115)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,13 +35,14 @@ let package = Package(
 
         // MARK: - MLX runner module (v0.5)
         //
-        // Slice 1: seam only — delegates to EventDrivenRunner internally.
+        // Slice 2+: VectorizedFillSimulator imports AthenaBrokers directly
+        // to access CommissionModel and SlippageModel.
         // Later slices add mlx-swift as a conditional macOS/iOS dependency
-        // and replace the delegation with real tensor dispatch behind
+        // and replace the inner loops with real tensor dispatch behind
         // `#if canImport(MLX)` guards.
         .target(
             name: "AthenaMLX",
-            dependencies: ["AthenaCore", "AthenaBacktest", "AthenaSweep"]
+            dependencies: ["AthenaCore", "AthenaBrokers", "AthenaBacktest", "AthenaSweep"]
         ),
 
         // MARK: - Examples
@@ -149,7 +150,7 @@ let package = Package(
             name: "AthenaMLXTests",
             dependencies: [
                 "AthenaMLX", "AthenaSweep", "AthenaCore",
-                "AthenaBacktest", "AthenaIndicators",
+                "AthenaBrokers", "AthenaBacktest", "AthenaIndicators",
             ]
         ),
     ]

--- a/Sources/AthenaMLX/MLXBacktestRunner.swift
+++ b/Sources/AthenaMLX/MLXBacktestRunner.swift
@@ -46,10 +46,12 @@ public struct MLXBacktestRunner: BacktestRunner {
         bars: [Bar],
         config: BacktestConfig
     ) async throws -> BacktestResult {
-        // Fast path: VectorizableStrategy + NoTaxes regime.
+        // Fast path: VectorizableStrategy + NoTaxes + NoCorporateActions + single symbol.
         if let vs = strategy as? any VectorizableStrategy,
-           config.taxRegime is NoTaxes {
-            return vectorizedRun(strategy: vs, bars: bars, config: config)
+           config.taxRegime is NoTaxes,
+           config.corporateActions is NoCorporateActions,
+           Set(bars.map(\.symbol)).count <= 1 {
+            return try vectorizedRun(strategy: vs, bars: bars, config: config)
         }
         // Fallback: full event-driven engine.
         // Issue #114 will add explicit tests and documentation for the
@@ -74,7 +76,7 @@ public struct MLXBacktestRunner: BacktestRunner {
         strategy: any VectorizableStrategy,
         bars: [Bar],
         config: BacktestConfig
-    ) -> BacktestResult {
+    ) throws -> BacktestResult {
         // Filter and sort — same semantics as BacktestEngine.
         let filteredBars = bars
             .filter { $0.timestamp >= config.startDate && $0.timestamp <= config.endDate }
@@ -87,14 +89,10 @@ public struct MLXBacktestRunner: BacktestRunner {
         // Obtain signals (must match filteredBars.count by VectorizableStrategy contract).
         let signals = strategy.signals(for: filteredBars)
 
-        // Guard against a mismatch — surface it as a BacktestResult with
-        // initialEquity == finalEquity so callers can detect it without crashing.
+        // Contract violation: signal count must match bar count.
         guard signals.count == filteredBars.count else {
-            return BacktestResult(
-                initialEquity: config.initialCash,
-                finalEquity: config.initialCash,
-                snapshots: [],
-                fills: []
+            throw VectorizedFillSimulatorError.signalCountMismatch(
+                signalCount: signals.count, barCount: filteredBars.count
             )
         }
 

--- a/Sources/AthenaMLX/MLXBacktestRunner.swift
+++ b/Sources/AthenaMLX/MLXBacktestRunner.swift
@@ -7,7 +7,7 @@ import AthenaSweep
 /// A ``BacktestRunner`` with an MLX-backed fast path for vectorizable
 /// strategies on Apple Silicon (macOS / iOS).
 ///
-/// **Fast-path eligibility (later v0.5 slices):**
+/// ## Fast-path eligibility
 /// - The strategy must conform to ``VectorizableStrategy``.
 /// - The ``BacktestConfig`` must use ``NoTaxes`` (tax-regime vectorization
 ///   is out of scope for v0.5).
@@ -16,11 +16,14 @@ import AthenaSweep
 /// ``EventDrivenRunner`` per cell, so callers never need to handle the
 /// dispatch themselves.
 ///
-/// **v0.5 slice 1 (this file):** the seam is in place — `MLXBacktestRunner`
-/// fully conforms to ``BacktestRunner`` — but the tensor dispatch is
-/// delegated to ``EventDrivenRunner`` until later slices add real MLX work.
-/// Switching to `MLXBacktestRunner` today is safe and produces identical
-/// results to the event-driven path.
+/// ## v0.5 fast path
+/// For eligible cells, `MLXBacktestRunner` calls
+/// ``VectorizableStrategy/signals(for:)`` to obtain a per-bar long/flat
+/// signal array, then simulates fills and computes equity purely in Swift
+/// without spinning up the full actor-based backtest infrastructure.  In
+/// a later slice the inner loops will be replaced with MLX tensor
+/// operations behind `#if canImport(MLX)` guards; the observable
+/// `BacktestResult` shape is unchanged.
 ///
 /// ## Usage
 /// ```swift
@@ -38,21 +41,78 @@ public struct MLXBacktestRunner: BacktestRunner {
 
     // MARK: BacktestRunner
 
-    /// Run one backtest cell.
-    ///
-    /// **Slice 1 behaviour:** always delegates to ``EventDrivenRunner``.
-    /// Later slices will inspect `strategy` for ``VectorizableStrategy``
-    /// conformance and `config.taxRegime` for ``NoTaxes``; if both
-    /// conditions are met, real MLX tensor dispatch is used instead.
     public func run(
         strategy: any Strategy,
         bars: [Bar],
         config: BacktestConfig
     ) async throws -> BacktestResult {
+        // Fast path: VectorizableStrategy + NoTaxes regime.
+        if let vs = strategy as? any VectorizableStrategy,
+           config.taxRegime is NoTaxes {
+            return vectorizedRun(strategy: vs, bars: bars, config: config)
+        }
+        // Fallback: full event-driven engine.
+        // Issue #114 will add explicit tests and documentation for the
+        // non-VectorizableStrategy and non-NoTaxes fallback paths.
         return try await EventDrivenRunner().run(
             strategy: strategy,
             bars: bars,
             config: config
+        )
+    }
+
+    // MARK: - Vectorized execution
+
+    /// Execute a single backtest cell via the vectorized fill simulator.
+    ///
+    /// Steps:
+    ///  1. Filter and sort bars to the config date window (mirrors BacktestEngine).
+    ///  2. Obtain signals from the strategy's `signals(for:)` method.
+    ///  3. Simulate fills and equity reduction with `VectorizedFillSimulator`.
+    ///  4. Wrap into a `BacktestResult`.
+    private func vectorizedRun(
+        strategy: any VectorizableStrategy,
+        bars: [Bar],
+        config: BacktestConfig
+    ) -> BacktestResult {
+        // Filter and sort — same semantics as BacktestEngine.
+        let filteredBars = bars
+            .filter { $0.timestamp >= config.startDate && $0.timestamp <= config.endDate }
+            .sorted { $0.timestamp < $1.timestamp }
+
+        // Determine the primary symbol from the bar sequence.
+        // v0.5 scope: single-symbol strategies.
+        let symbol = filteredBars.first?.symbol ?? Symbol("UNKNOWN")
+
+        // Obtain signals (must match filteredBars.count by VectorizableStrategy contract).
+        let signals = strategy.signals(for: filteredBars)
+
+        // Guard against a mismatch — surface it as a BacktestResult with
+        // initialEquity == finalEquity so callers can detect it without crashing.
+        guard signals.count == filteredBars.count else {
+            return BacktestResult(
+                initialEquity: config.initialCash,
+                finalEquity: config.initialCash,
+                snapshots: [],
+                fills: []
+            )
+        }
+
+        let sim = VectorizedFillSimulator()
+        let result = sim.simulate(
+            symbol: symbol,
+            signals: signals,
+            bars: filteredBars,
+            initialCash: config.initialCash,
+            commission: config.commission,
+            slippage: config.slippage
+        )
+
+        return BacktestResult(
+            initialEquity: config.initialCash,
+            finalEquity: result.finalEquity,
+            snapshots: result.snapshots,
+            fills: result.fills
         )
     }
 }

--- a/Sources/AthenaMLX/VectorizedFillSimulator.swift
+++ b/Sources/AthenaMLX/VectorizedFillSimulator.swift
@@ -25,6 +25,17 @@ import AthenaBacktest
 // - Whole-share quantities only.
 // - Commission currency is assumed to match the base (initialCash) currency.
 
+enum VectorizedFillSimulatorError: Error, LocalizedError {
+    case signalCountMismatch(signalCount: Int, barCount: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .signalCountMismatch(let signalCount, let barCount):
+            return "VectorizedFillSimulator: signals.count (\(signalCount)) != bars.count (\(barCount))"
+        }
+    }
+}
+
 struct VectorizedFillSimulator {
 
     // MARK: - Public result type
@@ -93,6 +104,7 @@ struct VectorizedFillSimulator {
                             currency: currency
                         ) {
                             fills.append(fill)
+                            executedSignal = pendingSignal
                         }
                     } else {
                         // true → false: exit to flat
@@ -103,9 +115,9 @@ struct VectorizedFillSimulator {
                             currency: currency
                         ) {
                             fills.append(fill)
+                            executedSignal = pendingSignal
                         }
                     }
-                    executedSignal = pendingSignal
                 }
             }
 
@@ -189,7 +201,7 @@ struct VectorizedFillSimulator {
             : 0
 
         return Fill(
-            orderId: UUID(),
+            orderId: finalOrder.id,
             symbol: symbol,
             side: .buy,
             quantity: qty,
@@ -227,7 +239,7 @@ struct VectorizedFillSimulator {
             : 0
 
         return Fill(
-            orderId: UUID(),
+            orderId: sellOrder.id,
             symbol: symbol,
             side: .sell,
             quantity: qty,

--- a/Sources/AthenaMLX/VectorizedFillSimulator.swift
+++ b/Sources/AthenaMLX/VectorizedFillSimulator.swift
@@ -1,0 +1,268 @@
+import Foundation
+import AthenaCore
+import AthenaBrokers
+import AthenaBacktest
+
+// MARK: - VectorizedFillSimulator
+//
+// Lightweight, value-semantic fill simulation for the AthenaMLX fast path.
+//
+// This type is *internal* to AthenaMLX and must not appear in Athena's
+// public API. It implements the same observable fill semantics as
+// BacktestEngine/SimulatedBroker for the v0.5 long/flat scope:
+//
+// - signals[i] = desired position AFTER the strategy processes bar[i]
+//   (based on bar[i].close).  The fill that acts on that decision lands at
+//   bar[i+1].open — identical to the event-driven "submit then fill next
+//   bar" loop.
+// - Going long  (false → true): buy floor(availableCash / fillPrice) shares.
+// - Going flat  (true → false): sell the entire position.
+// - A transition on the final bar has no next open and is never filled.
+//
+// v0.5 constraints (out of scope for later slices):
+// - Single-symbol bars only.
+// - NoTaxes regime; the caller is responsible for checking this.
+// - Whole-share quantities only.
+// - Commission currency is assumed to match the base (initialCash) currency.
+
+struct VectorizedFillSimulator {
+
+    // MARK: - Public result type
+
+    struct SimulationResult {
+        let fills: [Fill]
+        let snapshots: [PortfolioSnapshot]
+        let finalEquity: Money
+    }
+
+    // MARK: - Entry point
+
+    /// Simulate a long/flat signal sequence against a bar array.
+    ///
+    /// - Parameters:
+    ///   - symbol:      The traded symbol (used to populate fills).
+    ///   - signals:     Per-bar position intent; must equal `bars.count`.
+    ///   - bars:        Pre-filtered and sorted bar array (caller's responsibility).
+    ///   - initialCash: Starting portfolio cash.
+    ///   - commission:  Commission model (default `FreeCommission`).
+    ///   - slippage:    Slippage model (default `FixedBpsSlippage(bps: 2)`).
+    /// - Returns: Fills, per-bar snapshots, and final equity.
+    func simulate(
+        symbol: Symbol,
+        signals: [Bool],
+        bars: [Bar],
+        initialCash: Money,
+        commission: any CommissionModel,
+        slippage: any SlippageModel
+    ) -> SimulationResult {
+        precondition(
+            signals.count == bars.count,
+            "VectorizedFillSimulator: signals.count (\(signals.count)) != bars.count (\(bars.count))"
+        )
+        guard !bars.isEmpty else {
+            return SimulationResult(fills: [], snapshots: [], finalEquity: initialCash)
+        }
+
+        let currency = initialCash.currency
+        var cash: Decimal = initialCash.amount
+        var positionQty: Decimal = 0
+        var fills: [Fill] = []
+        var snapshots: [PortfolioSnapshot] = []
+
+        // executedSignal: the position we are ACTUALLY holding right now.
+        // Starts as false (flat) before the first bar.
+        var executedSignal = false
+
+        for i in bars.indices {
+            let bar = bars[i]
+
+            // ── Step 1: Execute fill at bar[i].open for the transition
+            //    that signals[i-1] requested.
+            //
+            //    When i == 0 there is no previous signal, so no fill is
+            //    possible at the opening of the first bar.
+            if i > 0 {
+                let pendingSignal = signals[i - 1]
+                if pendingSignal != executedSignal {
+                    if pendingSignal {
+                        // false → true: enter long
+                        if let fill = executeBuy(
+                            symbol: symbol, bar: bar,
+                            cash: &cash, positionQty: &positionQty,
+                            commission: commission, slippage: slippage,
+                            currency: currency
+                        ) {
+                            fills.append(fill)
+                        }
+                    } else {
+                        // true → false: exit to flat
+                        if let fill = executeSell(
+                            symbol: symbol, bar: bar,
+                            cash: &cash, positionQty: &positionQty,
+                            commission: commission, slippage: slippage,
+                            currency: currency
+                        ) {
+                            fills.append(fill)
+                        }
+                    }
+                    executedSignal = pendingSignal
+                }
+            }
+
+            // ── Step 2: Snapshot at bar[i].close (mark-to-market).
+            let totalValue = cash + positionQty * bar.close
+            let snap = PortfolioSnapshot(
+                timestamp: bar.timestamp,
+                totalValue: Money(totalValue, currency),
+                cash: [currency: cash],
+                positions: positionQty > 0 ? [symbol: positionQty] : [:]
+            )
+            snapshots.append(snap)
+        }
+
+        // Final equity: remaining cash + open position marked to last close.
+        let lastClose = bars.last!.close
+        let finalEquity = Money(cash + positionQty * lastClose, currency)
+        return SimulationResult(fills: fills, snapshots: snapshots, finalEquity: finalEquity)
+    }
+
+    // MARK: - Private helpers
+
+    /// Execute a long-entry fill at `bar.open`.
+    ///
+    /// Buys as many whole shares as the available cash permits after
+    /// accounting for slippage and commission. Returns `nil` when cash
+    /// is insufficient for at least one share.
+    private func executeBuy(
+        symbol: Symbol,
+        bar: Bar,
+        cash: inout Decimal,
+        positionQty: inout Decimal,
+        commission: any CommissionModel,
+        slippage: any SlippageModel,
+        currency: Currency
+    ) -> Fill? {
+        guard cash > 0 else { return nil }
+
+        // ── Pass 1: estimate fill price and quantity without commission.
+        //
+        // We use qty=1 for the first slippage probe because:
+        //   * FixedBpsSlippage ignores quantity → exact result immediately.
+        //   * VolumeImpactSlippage scales with sqrt(qty/volume) → the
+        //     estimated fill price is slightly low, but the second pass
+        //     corrects it.
+        let probe1 = syntheticOrder(symbol: symbol, side: .buy, qty: 1, at: bar.timestamp)
+        let fillPrice1 = slippage.fillPrice(referencePrice: bar.open, order: probe1, bar: bar)
+        guard fillPrice1 > 0 else { return nil }
+
+        var qty = floorDecimal(cash / fillPrice1)
+        guard qty >= 1 else { return nil }
+
+        // ── Pass 2: apply slippage and commission for the estimated qty.
+        //
+        // This pass handles VolumeImpactSlippage (qty-dependent) and
+        // PerShareCommission (qty-dependent) accurately.
+        let probe2 = syntheticOrder(symbol: symbol, side: .buy, qty: qty, at: bar.timestamp)
+        let fillPrice2 = slippage.fillPrice(referencePrice: bar.open, order: probe2, bar: bar)
+        guard fillPrice2 > 0 else { return nil }
+
+        let comm2 = commission.commission(for: probe2, fillPrice: fillPrice2)
+        let cashAfterComm = cash - comm2.amount
+        guard cashAfterComm > 0 else { return nil }
+
+        qty = floorDecimal(cashAfterComm / fillPrice2)
+        guard qty >= 1 else { return nil }
+
+        // ── Finalise: compute exact fill price and commission for the
+        //    adjusted quantity, then verify total cost fits in cash.
+        let finalOrder = syntheticOrder(symbol: symbol, side: .buy, qty: qty, at: bar.timestamp)
+        let finalFillPrice = slippage.fillPrice(referencePrice: bar.open, order: finalOrder, bar: bar)
+        let finalComm = commission.commission(for: finalOrder, fillPrice: finalFillPrice)
+        let totalCost = qty * finalFillPrice + finalComm.amount
+        guard totalCost <= cash else { return nil }
+
+        cash -= totalCost
+        positionQty = qty
+
+        let slippageBps = bar.open > 0
+            ? ((finalFillPrice - bar.open) / bar.open) * 10_000
+            : 0
+
+        return Fill(
+            orderId: UUID(),
+            symbol: symbol,
+            side: .buy,
+            quantity: qty,
+            price: finalFillPrice,
+            commission: finalComm,
+            slippageBps: slippageBps,
+            filledAt: bar.timestamp
+        )
+    }
+
+    /// Execute a flat-exit fill at `bar.open`. Sells the entire position.
+    /// Returns `nil` when there is nothing to sell.
+    private func executeSell(
+        symbol: Symbol,
+        bar: Bar,
+        cash: inout Decimal,
+        positionQty: inout Decimal,
+        commission: any CommissionModel,
+        slippage: any SlippageModel,
+        currency: Currency
+    ) -> Fill? {
+        guard positionQty > 0 else { return nil }
+
+        let qty = positionQty
+        let sellOrder = syntheticOrder(symbol: symbol, side: .sell, qty: qty, at: bar.timestamp)
+        let fillPrice = slippage.fillPrice(referencePrice: bar.open, order: sellOrder, bar: bar)
+        let comm = commission.commission(for: sellOrder, fillPrice: fillPrice)
+
+        let proceeds = qty * fillPrice - comm.amount
+        cash += proceeds
+        positionQty = 0
+
+        let slippageBps = bar.open > 0
+            ? ((fillPrice - bar.open) / bar.open) * 10_000
+            : 0
+
+        return Fill(
+            orderId: UUID(),
+            symbol: symbol,
+            side: .sell,
+            quantity: qty,
+            price: fillPrice,
+            commission: comm,
+            slippageBps: slippageBps,
+            filledAt: bar.timestamp
+        )
+    }
+
+    // MARK: - Utilities
+
+    /// Build a minimal Order for passing to CommissionModel / SlippageModel.
+    private func syntheticOrder(
+        symbol: Symbol,
+        side: Side,
+        qty: Decimal,
+        at timestamp: Date
+    ) -> Order {
+        Order(
+            symbol: symbol,
+            side: side,
+            quantity: qty,
+            type: .market,
+            tif: .day,
+            createdAt: timestamp
+        )
+    }
+
+    /// Floor a Decimal to the nearest integer (rounds toward zero for
+    /// positive values, which is the desired "whole shares" behaviour).
+    private func floorDecimal(_ value: Decimal) -> Decimal {
+        var result = Decimal()
+        var input = value
+        NSDecimalRound(&result, &input, 0, .down)
+        return result
+    }
+}

--- a/Tests/AthenaMLXTests/MLXEquivalenceGateTests.swift
+++ b/Tests/AthenaMLXTests/MLXEquivalenceGateTests.swift
@@ -6,23 +6,30 @@ import AthenaSweep
 
 // MARK: - Equivalence tolerance
 //
-// A single constant applied to all numeric comparisons in the equivalence gate.
+// What "equivalence" means once the vectorized fast path is active
+// ────────────────────────────────────────────────────────────────
+// The two runners intentionally differ in position sizing: the
+// `VectorizableStrategy` contract is "fully in" (the simulator buys
+// floor(availableCash / fillPrice) shares at the next open), while an
+// event-driven strategy cannot know the next bar's open at order-submission
+// time and therefore cannot reproduce that quantity exactly. Equity-level
+// metrics are consequently NOT comparable across runners.
 //
-// `totalReturn`, `maxDrawdown`, and `finalEquity` use `Decimal` arithmetic
-// internally and are converted to `Double` for cross-runner comparison.
-// `sharpe` is already a `Double`. `fills.count` is an integer and always
-// compared with exact equality.
-//
-// Exact equality holds while `MLXBacktestRunner` delegates to
-// `EventDrivenRunner` (both runners share the same code path). The tolerance
-// accommodates expected IEEE 754 rounding once MLX tensor dispatch replaces
-// the delegation in a later slice.
+// The gate therefore asserts two things:
+// 1. Cross-runner *fill structure* equivalence — both runners must produce
+//    the same number of fills, on the same bars, on the same sides, at the
+//    same prices. This proves the vectorized signal → fill translation
+//    matches the event-driven engine's timing and pricing semantics.
+// 2. Vectorized *metrics* against golden values captured from the seeded,
+//    deterministic canonical fixture. This is the drift net that catches
+//    numerical changes when MLX tensor ops replace the Swift loops.
 
-/// Shared numeric tolerance for all MLX vs EventDriven equivalence assertions.
-///
-/// Applied to `totalReturn`, `maxDrawdown`, `sharpe`, and `finalEquity`.
-/// `fills.count` is always compared with exact equality.
-private let EquivalenceTolerance: Double = 1e-9
+/// Tolerance for cross-runner fill-price comparisons and golden-value
+/// ratio metrics (`totalReturn`, `maxDrawdown`, `sharpe`).
+private let EquivalenceTolerance: Double = 1e-6
+
+/// Tolerance for golden `finalEquity` comparisons (dollar scale).
+private let EquityTolerance: Double = 0.01
 
 // MARK: - Canonical fixture strategy
 
@@ -38,9 +45,10 @@ private let EquivalenceTolerance: Double = 1e-9
 /// is the event-driven equivalent used by `EventDrivenRunner` (and by
 /// `MLXBacktestRunner` while the fast path is still in delegation mode).
 ///
-/// The trade quantity is fixed at 100 shares per buy so that the vectorized
-/// fill simulator and the event-driven engine produce the same fills when they
-/// execute an identical signal sequence.
+/// The event-driven path trades a fixed 100 shares per buy; the vectorized
+/// path trades all-in per the ``VectorizableStrategy`` contract. Sizing
+/// therefore differs by design — the gate compares fill structure (count,
+/// timing, side, price), not equity, across runners.
 private struct SMALongFlatFixture: Strategy, VectorizableStrategy {
     let symbol: Symbol
     let fastPeriod: Int
@@ -65,6 +73,15 @@ private struct SMALongFlatFixture: Strategy, VectorizableStrategy {
     }
 
     // MARK: Strategy
+
+    /// Pre-register both SMAs so the indicator cache feeds them from bar 0.
+    /// Without this, lazily-created indicators start one bar late (documented
+    /// Indicators caveat), shifting crossovers near the warm-up boundary and
+    /// breaking fill-structure equivalence with the vectorized path.
+    func onStart(context: StrategyContext) async throws {
+        _ = await context.indicators.sma(symbol, period: fastPeriod)
+        _ = await context.indicators.sma(symbol, period: slowPeriod)
+    }
 
     /// Event-driven execution: mirrors the vectorized signal using the indicator cache.
     ///
@@ -145,47 +162,55 @@ private func makeEquivalenceFactory(symbol: Symbol) -> ClosureStrategyFactory {
     }
 }
 
+// MARK: - Golden values
+//
+// Captured from the seeded canonical fixture (Xoshiro256** seed 0xA1B2_C3D4,
+// 300 bars, Decimal arithmetic) with the pure-Swift vectorized fast path.
+// Regenerate by printing the vectorized sweep results if the fixture, the
+// fill contract, or the metric definitions intentionally change.
+private struct GoldenCell {
+    let fast: Int
+    let slow: Int
+    let fills: Int
+    let totalReturn: Double
+    let maxDrawdown: Double
+    let sharpe: Double
+    let finalEquity: Double
+}
+
+private let goldenCells: [GoldenCell] = [
+    GoldenCell(fast: 5,  slow: 20, fills: 15, totalReturn: -0.07301775311022075,
+               maxDrawdown: 0.17834115962037883, sharpe: -0.46116569558400955,
+               finalEquity: 92_698.22468897786),
+    GoldenCell(fast: 5,  slow: 50, fills: 13, totalReturn: -0.0885532531484274,
+               maxDrawdown: 0.1958997936588363, sharpe: -0.622992349646425,
+               finalEquity: 91_144.67468515722),
+    GoldenCell(fast: 10, slow: 20, fills: 15, totalReturn: -0.028595590759415635,
+               maxDrawdown: 0.1722558081460317, sharpe: -0.14369920190938312,
+               finalEquity: 97_140.44092405846),
+    GoldenCell(fast: 10, slow: 50, fills: 11, totalReturn: -0.05600762337800874,
+               maxDrawdown: 0.1924136492571617, sharpe: -0.3459208053246339,
+               finalEquity: 94_399.23766219914),
+]
+
 // MARK: - MLX equivalence gate
-//
-// Platform note
-// ─────────────
-// On platforms where the MLX framework is available (`canImport(MLX)` in
-// MLXBacktestRunner.swift), `MLXBacktestRunner` routes `VectorizableStrategy`
-// + `NoTaxes` cells through its tensor fast path. On all other platforms the
-// runner delegates those cells to `EventDrivenRunner`, keeping CI green on
-// non-Apple-Silicon builds.
-//
-// The tests below run on *all* platforms. On non-MLX platforms the gate passes
-// trivially (both runners share the same event-driven code path, so results
-// are exactly equal). On MLX platforms the gate enforces that tensor dispatch
-// stays within `EquivalenceTolerance` of the event-driven baseline — which is
-// the primary safety net that catches numerical drift when the fast path is
-// active.
 
 /// Equivalence gate between `MLXBacktestRunner` and `EventDrivenRunner` on a
 /// canonical long/flat `VectorizableStrategy` fixture.
 ///
 /// ## What this tests
-/// - Five observable metrics per cell, in result (parameter-grid) order:
-///   total return, max drawdown, Sharpe, final equity, and fill count.
-/// - All numeric comparisons use a single documented `EquivalenceTolerance`.
-/// - Integer metrics (`fills.count`) are always compared with exact equality.
-///
-/// ## Platform behaviour
-/// Non-MLX platforms: both runners delegate to `EventDrivenRunner`; the gate
-/// passes trivially (exact equality). Existing test coverage is unaffected.
-/// MLX platforms: the fast path's tensor dispatch must stay within tolerance
-/// of the event-driven baseline; any drift causes the gate to fail.
+/// - **Cross-runner fill structure**: both runners must produce the same
+///   number of fills per cell, on the same bars, same sides, same prices.
+///   Position *sizing* intentionally differs (see `EquivalenceTolerance`
+///   note above), so equity metrics are not compared across runners.
+/// - **Vectorized metrics vs goldens**: total return, max drawdown, Sharpe,
+///   final equity, and fill count per cell, pinned to values captured from
+///   the deterministic fixture. This catches numerical drift when MLX tensor
+///   dispatch replaces the pure-Swift loops (HQ#116).
 final class MLXEquivalenceGateTests: XCTestCase {
 
-    // MARK: Primary gate: all five metrics, in result order
+    // MARK: Primary gate: fill structure + golden metrics, in result order
 
-    /// Run the canonical SMA long/flat sweep through both runners and assert
-    /// that total return, max drawdown, Sharpe, final equity, and fill count
-    /// match within `EquivalenceTolerance` for every cell, in result order.
-    ///
-    /// This is the primary CI gate for the v0.5 MLX equivalence requirement
-    /// (HQ#116).
     func test_canonicalFixture_allFiveMetrics_matchInResultOrder() async {
         let sym = Symbol("EQ")
         let bars = makeEquivalenceBars(symbol: sym)
@@ -205,6 +230,10 @@ final class MLXEquivalenceGateTests: XCTestCase {
             mlxResults.count, edResults.count,
             "Both runners must return the same number of sweep results"
         )
+        XCTAssertEqual(
+            mlxResults.count, goldenCells.count,
+            "Golden table must cover every canonical grid cell"
+        )
 
         for (i, (mlx, ed)) in zip(mlxResults, edResults).enumerated() {
             guard let mlxBT = mlx.backtest, let edBT = ed.backtest else {
@@ -215,41 +244,60 @@ final class MLXEquivalenceGateTests: XCTestCase {
                 continue
             }
 
-            // 1. Total return
-            XCTAssertEqual(
-                NSDecimalNumber(decimal: mlxBT.totalReturn).doubleValue,
-                NSDecimalNumber(decimal: edBT.totalReturn).doubleValue,
-                accuracy: EquivalenceTolerance,
-                "Cell \(i) [\(mlx.params)]: totalReturn mismatch"
-            )
-
-            // 2. Max drawdown
-            XCTAssertEqual(
-                NSDecimalNumber(decimal: mlxBT.maxDrawdown).doubleValue,
-                NSDecimalNumber(decimal: edBT.maxDrawdown).doubleValue,
-                accuracy: EquivalenceTolerance,
-                "Cell \(i) [\(mlx.params)]: maxDrawdown mismatch"
-            )
-
-            // 3. Sharpe (already Double)
-            XCTAssertEqual(
-                mlxBT.sharpe, edBT.sharpe,
-                accuracy: EquivalenceTolerance,
-                "Cell \(i) [\(mlx.params)]: sharpe mismatch"
-            )
-
-            // 4. Final equity
-            XCTAssertEqual(
-                NSDecimalNumber(decimal: mlxBT.finalEquity.amount).doubleValue,
-                NSDecimalNumber(decimal: edBT.finalEquity.amount).doubleValue,
-                accuracy: EquivalenceTolerance,
-                "Cell \(i) [\(mlx.params)]: finalEquity mismatch"
-            )
-
-            // 5. Fill count — integer; no tolerance required
+            // ── Cross-runner fill structure ──────────────────────────────
             XCTAssertEqual(
                 mlxBT.fills.count, edBT.fills.count,
-                "Cell \(i) [\(mlx.params)]: fills.count mismatch"
+                "Cell \(i) [\(mlx.params)]: fills.count mismatch across runners"
+            )
+            for (j, (mf, ef)) in zip(mlxBT.fills, edBT.fills).enumerated() {
+                XCTAssertEqual(
+                    mf.filledAt, ef.filledAt,
+                    "Cell \(i) fill \(j): timestamp mismatch across runners"
+                )
+                XCTAssertEqual(
+                    mf.side, ef.side,
+                    "Cell \(i) fill \(j): side mismatch across runners"
+                )
+                XCTAssertEqual(
+                    NSDecimalNumber(decimal: mf.price).doubleValue,
+                    NSDecimalNumber(decimal: ef.price).doubleValue,
+                    accuracy: EquivalenceTolerance,
+                    "Cell \(i) fill \(j): price mismatch across runners"
+                )
+            }
+
+            // ── Vectorized metrics vs goldens ────────────────────────────
+            let golden = goldenCells[i]
+            XCTAssertEqual(mlx.params.int("fast"), golden.fast,
+                           "Cell \(i): golden table out of sync with grid order")
+            XCTAssertEqual(mlx.params.int("slow"), golden.slow,
+                           "Cell \(i): golden table out of sync with grid order")
+            XCTAssertEqual(
+                mlxBT.fills.count, golden.fills,
+                "Cell \(i) [\(mlx.params)]: fills.count drifted from golden"
+            )
+            XCTAssertEqual(
+                NSDecimalNumber(decimal: mlxBT.totalReturn).doubleValue,
+                golden.totalReturn,
+                accuracy: EquivalenceTolerance,
+                "Cell \(i) [\(mlx.params)]: totalReturn drifted from golden"
+            )
+            XCTAssertEqual(
+                NSDecimalNumber(decimal: mlxBT.maxDrawdown).doubleValue,
+                golden.maxDrawdown,
+                accuracy: EquivalenceTolerance,
+                "Cell \(i) [\(mlx.params)]: maxDrawdown drifted from golden"
+            )
+            XCTAssertEqual(
+                mlxBT.sharpe, golden.sharpe,
+                accuracy: EquivalenceTolerance,
+                "Cell \(i) [\(mlx.params)]: sharpe drifted from golden"
+            )
+            XCTAssertEqual(
+                NSDecimalNumber(decimal: mlxBT.finalEquity.amount).doubleValue,
+                golden.finalEquity,
+                accuracy: EquityTolerance,
+                "Cell \(i) [\(mlx.params)]: finalEquity drifted from golden"
             )
         }
     }

--- a/Tests/AthenaMLXTests/VectorizedFillSimulatorTests.swift
+++ b/Tests/AthenaMLXTests/VectorizedFillSimulatorTests.swift
@@ -1,0 +1,616 @@
+import XCTest
+import AthenaCore
+import AthenaBrokers
+import AthenaBacktest
+import AthenaSweep
+@testable import AthenaMLX
+
+// MARK: - Shared fixtures (scoped to this file)
+
+/// A strategy whose signal array is supplied at init time.
+/// Used to verify hand-computed fill expectations without coupling tests
+/// to a specific indicator algorithm.
+private struct DefinedSignalStrategy: Strategy, VectorizableStrategy {
+    let symbol: Symbol
+    let signalArray: [Bool]
+
+    func onBar(_ bar: Bar, context: StrategyContext) async throws {}
+    func signals(for bars: [Bar]) -> [Bool] { signalArray }
+}
+
+private func makeBars(
+    _ n: Int,
+    symbol: Symbol = Symbol("T"),
+    opens: [Decimal]? = nil
+) -> [Bar] {
+    let base = Date(timeIntervalSince1970: 0)
+    return (0..<n).map { i in
+        let open = opens?[i] ?? Decimal(100 + i)
+        return Bar(
+            symbol: symbol,
+            timestamp: base.addingTimeInterval(Double(i) * 86_400),
+            open: open,
+            high: open + 2,
+            low: open - 1,
+            close: open,
+            volume: 1_000_000
+        )
+    }
+}
+
+private func makeConfig(bars: [Bar]) -> BacktestConfig {
+    BacktestConfig(
+        startDate: bars.first!.timestamp,
+        endDate: bars.last!.timestamp,
+        initialCash: .usd(10_000)
+    )
+}
+
+// MARK: - VectorizedFillSimulator unit tests
+//
+// These tests exercise the simulator in isolation using hand-computed
+// inputs and expected outputs. No MLX framework is needed — the simulator
+// is pure Swift math.
+
+final class VectorizedFillSimulatorFillTests: XCTestCase {
+
+    // MARK: AC1 — fills land at the correct bar's open
+
+    /// Flat-to-long transition at bar[1] → buy at bar[2].open.
+    /// Long-to-flat transition at bar[3] → sell at bar[4].open.
+    ///
+    /// signals = [F, T, T, F, F]
+    ///           ↑      ↑
+    ///    bar[1]=T→buy at bar[2].open
+    ///                  bar[3]=F→sell at bar[4].open
+    func test_fillsLandAtNextBarOpen_oneRoundTrip() {
+        let sym = Symbol("T")
+        let bars = makeBars(5, symbol: sym, opens: [100, 101, 102, 103, 104])
+        let signals = [false, true, true, false, false]
+
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym,
+            signals: signals,
+            bars: bars,
+            initialCash: .usd(10_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: NoSlippage()
+        )
+
+        XCTAssertEqual(result.fills.count, 2, "Exactly one buy + one sell fill")
+        XCTAssertEqual(result.fills[0].side, .buy,  "First fill is a buy")
+        XCTAssertEqual(result.fills[0].price, 102,  "Buy at bar[2].open = 102")
+        XCTAssertEqual(result.fills[1].side, .sell, "Second fill is a sell")
+        XCTAssertEqual(result.fills[1].price, 104,  "Sell at bar[4].open = 104")
+    }
+
+    /// signals[0]=T triggers the first transition; buy fills at bar[1].open.
+    func test_fillsLandAtNextBarOpen_entryOnFirstSignal() {
+        let sym = Symbol("T")
+        let bars = makeBars(3, symbol: sym, opens: [100, 101, 102])
+        let signals = [true, true, true]   // always long
+
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym,
+            signals: signals,
+            bars: bars,
+            initialCash: .usd(10_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: NoSlippage()
+        )
+
+        XCTAssertEqual(result.fills.count, 1, "One buy fill for always-long over 3 bars")
+        XCTAssertEqual(result.fills[0].side, .buy)
+        XCTAssertEqual(result.fills[0].price, 101, "Buy at bar[1].open = 101")
+    }
+
+    /// Flat throughout → no fills at all.
+    func test_alwaysFlatProducesNoFills() {
+        let sym = Symbol("T")
+        let bars = makeBars(5, symbol: sym)
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym,
+            signals: [false, false, false, false, false],
+            bars: bars,
+            initialCash: .usd(10_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: NoSlippage()
+        )
+        XCTAssertTrue(result.fills.isEmpty, "Flat strategy must produce no fills")
+    }
+
+    /// A transition on the FINAL bar has no next open and must not produce a fill.
+    func test_finalBarTransitionIsNotFilled() {
+        let sym = Symbol("T")
+        let bars = makeBars(3, symbol: sym)
+        // signals[2] = true is on the final bar — no next bar to fill at.
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym,
+            signals: [false, false, true],
+            bars: bars,
+            initialCash: .usd(10_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: NoSlippage()
+        )
+        XCTAssertEqual(result.fills.count, 0,
+                       "Transition on the final bar must not produce a fill")
+    }
+
+    /// Rapid toggles: F→T→F→T→F over 5 bars produces 2 buys and 1 sell.
+    /// signals = [F, T, F, T, F]
+    ///   bar[1]=T → buy at bar[2].open
+    ///   bar[2]=F → sell at bar[3].open
+    ///   bar[3]=T → buy at bar[4].open
+    ///   bar[4]=F → final bar, no fill
+    func test_rapidTogglesProduceCorrectFills() {
+        let sym = Symbol("T")
+        let bars = makeBars(5, symbol: sym, opens: [100, 101, 102, 103, 104])
+        let signals = [false, true, false, true, false]
+
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym,
+            signals: signals,
+            bars: bars,
+            initialCash: .usd(10_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: NoSlippage()
+        )
+
+        // Transitions:
+        // bar[1]=T → buy at bar[2].open=102
+        // bar[2]=F → sell at bar[3].open=103
+        // bar[3]=T → buy at bar[4].open=104
+        // bar[4]=F → final bar, not filled
+        XCTAssertEqual(result.fills.count, 3, "2 buys + 1 sell")
+        XCTAssertEqual(result.fills[0].side, .buy)
+        XCTAssertEqual(result.fills[0].price, 102)
+        XCTAssertEqual(result.fills[1].side, .sell)
+        XCTAssertEqual(result.fills[1].price, 103)
+        XCTAssertEqual(result.fills[2].side, .buy)
+        XCTAssertEqual(result.fills[2].price, 104)
+    }
+
+    /// Single bar: the only signal is on the final bar — no fill possible.
+    func test_singleBar_noFills() {
+        let sym = Symbol("T")
+        let bar = makeBars(1, symbol: sym)
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym, signals: [true], bars: bar,
+            initialCash: .usd(10_000), commission: FreeCommission(currency: .usd), slippage: NoSlippage()
+        )
+        XCTAssertEqual(result.fills.count, 0)
+    }
+
+    /// Empty bars produce an empty result without crashing.
+    func test_emptyBars_noFills() {
+        let sym = Symbol("T")
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym, signals: [], bars: [],
+            initialCash: .usd(10_000), commission: FreeCommission(currency: .usd), slippage: NoSlippage()
+        )
+        XCTAssertTrue(result.fills.isEmpty)
+        XCTAssertTrue(result.snapshots.isEmpty)
+        XCTAssertEqual(result.finalEquity, .usd(10_000))
+    }
+}
+
+// MARK: - Fill quantity & equity tests
+
+final class VectorizedFillSimulatorEquityTests: XCTestCase {
+
+    // MARK: AC1 — buy quantity
+
+    /// Buy uses all available cash (floor-shares) when FreeCommission + NoSlippage.
+    /// initialCash=$10 000, open=100 → 100 shares bought.
+    func test_buyQtyUsesAllAvailableCash_noSlippageNoCommission() {
+        let sym = Symbol("T")
+        // bar[0]: F, bar[1]: T → buy at bar[1].open, bar[2]: T (hold)
+        let bars = makeBars(3, symbol: sym, opens: [100, 100, 100])
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym,
+            signals: [false, true, true],
+            bars: bars,
+            initialCash: .usd(10_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: NoSlippage()
+        )
+        // signals[0]=false, signals[1]=true → buy at bars[1].open=100 → 100 shares
+        XCTAssertEqual(result.fills.count, 1)
+        XCTAssertEqual(result.fills[0].quantity, 100, "Buy 100 shares at $100 with $10 000 cash")
+    }
+
+    /// Sell disposes of the entire position.
+    func test_sellDisposesEntirePosition() {
+        let sym = Symbol("T")
+        let bars = makeBars(4, symbol: sym, opens: [100, 100, 100, 100])
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym,
+            signals: [false, true, false, false],
+            bars: bars,
+            initialCash: .usd(10_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: NoSlippage()
+        )
+        // signals[0]=F, signals[1]=T → buy at bar[1].open=100 → 100 shares
+        // signals[2]=F → sell at bar[2+1=3].open... wait let me recheck
+        // Actually: signals[1]=true (transition from false to true) → buy at bar[1+1=2].open
+        // Wait, I need to re-check the logic.
+        //
+        // The transition happens BETWEEN consecutive signals.
+        // signals = [F, T, F, F]
+        // Transition 1: signals[0]=F → signals[1]=T: fill at bar[1].open? No...
+        //
+        // Per the contract: "A transition from false→true triggers a buy at the NEXT bar's open"
+        // signals[i] = desired position after bar i
+        // So signals[0]=F after bar 0, signals[1]=T after bar 1:
+        //   transition signals[0]→signals[1]: fills at bar[1+1=2]? No...
+        //
+        // Actually reading VectorizableStrategy more carefully:
+        // signals[i] = target after bar[i].close (i.e., based on seeing bar[i])
+        // The "next bar's open" = bar[i+1].open
+        //
+        // But my algorithm uses:
+        // At bar[i]: check signals[i-1] vs executedPosition → fill at bar[i].open
+        // = transition from signals[i-1] fills at bar[i].open
+        //
+        // So:
+        // signals = [F, T, F, F]
+        // bar[0]: i=0, no prev signal, skip
+        // bar[1]: i=1, check signals[0]=F vs executed=F → no transition
+        // bar[2]: i=2, check signals[1]=T vs executed=F → BUY at bar[2].open
+        // bar[3]: i=3, check signals[2]=F vs executed=T → SELL at bar[3].open
+        //
+        // So: buy at bar[2].open=100, sell at bar[3].open=100
+        XCTAssertEqual(result.fills.count, 2)
+        let buyFill = result.fills.first(where: { $0.side == .buy })!
+        let sellFill = result.fills.first(where: { $0.side == .sell })!
+        XCTAssertEqual(sellFill.quantity, buyFill.quantity, "Sell qty must equal buy qty")
+    }
+
+    // MARK: AC2 — slippage reflected in fill price and equity
+
+    /// FixedBpsSlippage(bps: 10) on a buy:
+    /// open=100, fillPrice = 100 * (1 + 10/10_000) = 100.1
+    func test_slippageReflectedInBuyFillPrice() {
+        let sym = Symbol("T")
+        // signals = [F, T, T] → buy at bar[1].open=100
+        let bars = makeBars(3, symbol: sym, opens: [100, 100, 100])
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym,
+            signals: [false, true, true],
+            bars: bars,
+            initialCash: .usd(10_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: FixedBpsSlippage(bps: 10)
+        )
+        let fill = result.fills.first(where: { $0.side == .buy })!
+        let expectedPrice = Decimal(100) * (1 + Decimal(10) / Decimal(10_000))
+        XCTAssertEqual(fill.price, expectedPrice,
+                       "Buy fill price must apply FixedBpsSlippage(bps: 10)")
+    }
+
+    /// FixedBpsSlippage on a sell:
+    /// open=100, fillPrice = 100 * (1 - 10/10_000) = 99.9
+    func test_slippageReflectedInSellFillPrice() {
+        let sym = Symbol("T")
+        // signals = [T, F, F] → buy at bar[1].open=100, sell at bar[2].open... wait
+        // signals = [F, T, F] → buy at bar[1], sell at bar[2]
+        // Actually:
+        // bar[0]: no prev, skip
+        // bar[1]: signals[0]=F vs executed=F → no fill
+        // bar[2]: signals[1]=T vs executed=F → BUY at bar[2].open=100
+        // end: signals[2]=F but it's the last; need sell at bar[3]?
+        // Hmm, signals=[F,T,F] with 3 bars:
+        // bar[2]: signals[1]=T → BUY at bar[2].open
+        // No bar[3] to execute signals[2]=F
+        // So only 1 fill (buy). Need 4 bars.
+        let bars = makeBars(4, symbol: sym, opens: [100, 100, 100, 100])
+        let signals = [false, true, false, false]
+        // bar[0]: skip
+        // bar[1]: signals[0]=F → no fill
+        // bar[2]: signals[1]=T → BUY at bar[2].open=100
+        // bar[3]: signals[2]=F → SELL at bar[3].open=100
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym,
+            signals: signals,
+            bars: bars,
+            initialCash: .usd(10_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: FixedBpsSlippage(bps: 10)
+        )
+        let sellFill = result.fills.first(where: { $0.side == .sell })!
+        let expectedSellPrice = Decimal(100) * (1 - Decimal(10) / Decimal(10_000))
+        XCTAssertEqual(sellFill.price, expectedSellPrice,
+                       "Sell fill price must apply FixedBpsSlippage(bps: 10) negatively")
+    }
+
+    /// Fixed commission of $5 is deducted from final equity.
+    /// With initialCash=$1 000 and price=$100, no slippage:
+    ///   buy at bar[2].open: floor((1000-5)/100)=9 shares, cost=900+5=905, cash left=95
+    ///   sell at bar[4].open: proceeds=9*100-5=895, finalEquity=95+895=990
+    func test_fixedCommissionDeductedFromEquity() {
+        let sym = Symbol("T")
+        let bars = makeBars(5, symbol: sym, opens: [100, 100, 100, 100, 100])
+        let signals = [false, true, true, false, false]
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym,
+            signals: signals,
+            bars: bars,
+            initialCash: .usd(1_000),
+            commission: FixedCommission(amount: 5, currency: .usd),
+            slippage: NoSlippage()
+        )
+        // buy at bar[2].open=100, sell at bar[4].open=100
+        XCTAssertEqual(result.fills.count, 2)
+        XCTAssertEqual(result.fills[0].commission.amount, 5, "Buy commission = $5")
+        XCTAssertEqual(result.fills[1].commission.amount, 5, "Sell commission = $5")
+        XCTAssertEqual(result.finalEquity.amount, 990,
+                       "Two $5 commissions leave $10 round-trip cost")
+    }
+
+    // MARK: AC3 — snapshots and result shape
+
+    /// One snapshot per bar, each with a valid totalValue.
+    func test_snapshotCountMatchesBarCount() {
+        let sym = Symbol("T")
+        let bars = makeBars(5, symbol: sym)
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym,
+            signals: [false, true, true, false, false],
+            bars: bars,
+            initialCash: .usd(10_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: NoSlippage()
+        )
+        XCTAssertEqual(result.snapshots.count, bars.count,
+                       "Simulator must produce one snapshot per bar")
+    }
+
+    /// Snapshot timestamps align with bar timestamps.
+    func test_snapshotTimestampsMatchBars() {
+        let sym = Symbol("T")
+        let bars = makeBars(4, symbol: sym)
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym, signals: [false, false, false, false], bars: bars,
+            initialCash: .usd(10_000), commission: FreeCommission(currency: .usd), slippage: NoSlippage()
+        )
+        for (snap, bar) in zip(result.snapshots, bars) {
+            XCTAssertEqual(snap.timestamp, bar.timestamp)
+        }
+    }
+
+    /// While flat, snapshots report full initial cash as totalValue.
+    func test_flatStrategy_snapshotEqualsInitialCash() {
+        let sym = Symbol("T")
+        let bars = makeBars(3, symbol: sym, opens: [100, 100, 100])
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym, signals: [false, false, false], bars: bars,
+            initialCash: .usd(5_000), commission: FreeCommission(currency: .usd), slippage: NoSlippage()
+        )
+        for snap in result.snapshots {
+            XCTAssertEqual(snap.totalValue, .usd(5_000),
+                           "Flat strategy snapshot totalValue must equal initial cash")
+        }
+        XCTAssertEqual(result.finalEquity, .usd(5_000))
+    }
+
+    /// While holding a position, snapshots mark-to-market at bar's close.
+    ///
+    /// Signal trace (4 bars):
+    ///   signals = [F, T, T, T]
+    ///   bar[0]: no prev signal → flat snapshot
+    ///   bar[1]: signals[0]=F → no fill → flat snapshot
+    ///   bar[2]: signals[1]=T → BUY at bar[2].open=100 → snapshot at bar[2].close=110
+    ///   bar[3]: holding → snapshot at bar[3].close=110
+    func test_longPosition_snapshotMarksToMarketAtClose() {
+        let sym = Symbol("T")
+        let base = Date(timeIntervalSince1970: 0)
+        let bars: [Bar] = [
+            Bar(symbol: sym, timestamp: base,                         open: 100, high: 102, low: 99,  close: 100, volume: 1_000_000),
+            Bar(symbol: sym, timestamp: base + 86_400,                open: 100, high: 102, low: 99,  close: 100, volume: 1_000_000),
+            Bar(symbol: sym, timestamp: base + 86_400 * 2,            open: 100, high: 115, low: 99,  close: 110, volume: 1_000_000),
+            Bar(symbol: sym, timestamp: base + 86_400 * 3,            open: 110, high: 115, low: 109, close: 110, volume: 1_000_000),
+        ]
+        // signals = [F, T, T, T]: signals[1]=T triggers BUY at bar[2].open=100
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym,
+            signals: [false, true, true, true],
+            bars: bars,
+            initialCash: .usd(10_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: NoSlippage()
+        )
+        // BUY at bar[2].open=100: qty=100, cash=0
+        // Snapshot at bar[2].close=110: 100 * 110 + 0 = 11_000
+        let snap2 = result.snapshots[2]
+        XCTAssertEqual(snap2.totalValue.amount, 11_000,
+                       "Snapshot at bar[2].close must mark 100 shares at $110")
+    }
+
+    /// finalEquity matches the last snapshot's totalValue.
+    func test_finalEquityMatchesLastSnapshot() {
+        let sym = Symbol("T")
+        let bars = makeBars(5, symbol: sym)
+        let result = VectorizedFillSimulator().simulate(
+            symbol: sym, signals: [false, true, true, true, false],
+            bars: bars,
+            initialCash: .usd(10_000),
+            commission: FreeCommission(currency: .usd),
+            slippage: NoSlippage()
+        )
+        XCTAssertEqual(result.finalEquity.amount, result.snapshots.last!.totalValue.amount,
+                       "finalEquity must equal the last snapshot's totalValue")
+    }
+}
+
+// MARK: - MLXBacktestRunner dispatch tests
+//
+// These tests verify that `MLXBacktestRunner.run` routes
+// `VectorizableStrategy + NoTaxes` to the fast path.
+
+final class MLXRunnerDispatchTests: XCTestCase {
+
+    // MARK: AC3 — result shape
+
+    /// For a `VectorizableStrategy`, MLXBacktestRunner must produce a
+    /// BacktestResult with all five key metrics populated correctly.
+    func test_vectStrategy_resultHasTotalReturn_drawdown_sharpe_equity_fillCount() async throws {
+        let sym = Symbol("T")
+        // 20 bars, rising prices: open = 100+i, close = 100+i
+        let bars = makeBars(20, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let strategy = DefinedSignalStrategy(
+            symbol: sym,
+            signalArray: [Bool](repeating: true, count: 20)
+        )
+
+        let result = try await MLXBacktestRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+
+        // totalReturn is a Decimal computed property — just verify it's present
+        _ = result.totalReturn
+        // maxDrawdown is non-negative
+        XCTAssertGreaterThanOrEqual(result.maxDrawdown, 0)
+        // sharpe is a Double
+        _ = result.sharpe
+        // finalEquity is a Money
+        _ = result.finalEquity
+        // fillCount is well-defined
+        let fillCount = result.fills.count
+        XCTAssertGreaterThanOrEqual(fillCount, 0,
+                                    "fill count must be a non-negative integer")
+    }
+
+    /// VectorizableStrategy with NoTaxes → fills are generated via the vectorized path.
+    /// This is verified by checking that fills exist and have the expected timestamps
+    /// (i.e., the vectorized path ran, not just a no-op from the event-driven onBar).
+    func test_vectStrategy_noTaxes_fillsGeneratedByVectorizedPath() async throws {
+        let sym = Symbol("T")
+        let bars = makeBars(5, symbol: sym)
+        let config = makeConfig(bars: bars)
+        // Always-long: vectorized path should produce 1 buy fill at bar[1]
+        let strategy = DefinedSignalStrategy(
+            symbol: sym,
+            signalArray: [true, true, true, true, true]
+        )
+
+        let result = try await MLXBacktestRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+
+        // EventDrivenRunner with DefinedSignalStrategy.onBar (does nothing) → 0 fills
+        // Vectorized path → 1 buy fill at bar[1]
+        XCTAssertEqual(result.fills.count, 1,
+                       "Vectorized path must produce 1 buy fill for always-long strategy")
+        XCTAssertEqual(result.fills[0].side, .buy)
+    }
+
+    /// Snapshots count equals bar count for a vectorizable strategy.
+    func test_vectStrategy_snapshotCountEqualsBarCount() async throws {
+        let sym = Symbol("T")
+        let bars = makeBars(10, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let strategy = DefinedSignalStrategy(
+            symbol: sym,
+            signalArray: [Bool](repeating: false, count: 10)
+        )
+
+        let result = try await MLXBacktestRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+
+        XCTAssertEqual(result.snapshots.count, bars.count,
+                       "One snapshot per bar for vectorizable strategy")
+    }
+
+    /// totalReturn is zero for a flat strategy (no fills, equity unchanged).
+    func test_flatVectStrategy_totalReturnIsZero() async throws {
+        let sym = Symbol("T")
+        let bars = makeBars(5, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let strategy = DefinedSignalStrategy(
+            symbol: sym,
+            signalArray: [false, false, false, false, false]
+        )
+
+        let result = try await MLXBacktestRunner().run(
+            strategy: strategy, bars: bars, config: config
+        )
+
+        XCTAssertEqual(result.totalReturn, 0,
+                       "Flat strategy must have zero totalReturn")
+        XCTAssertEqual(result.finalEquity, config.initialCash,
+                       "Flat strategy must leave equity unchanged")
+    }
+
+    // MARK: AC4 — parameter order preserved
+
+    /// Grid sweep over a VectorizableStrategy preserves ParameterSet order.
+    func test_sweepWithVectStrategy_preservesParameterOrder() async {
+        let sym = Symbol("T")
+        let bars = makeBars(10, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let expectedQtys = [1, 2, 3, 4]
+        let space = ParameterSpace.grid([.ints("x", expectedQtys)])
+        let sym2 = sym
+
+        let factory = ClosureStrategyFactory { params -> any Strategy in
+            DefinedSignalStrategy(
+                symbol: sym2,
+                signalArray: [Bool](repeating: true, count: 10)
+            )
+        }
+        let results = await Sweep(
+            factory: factory,
+            runner: MLXBacktestRunner(),
+            bars: bars,
+            config: config,
+            space: space
+        ).run()
+
+        XCTAssertEqual(results.count, expectedQtys.count)
+        for (r, x) in zip(results, expectedQtys) {
+            XCTAssertEqual(r.params.int("x"), x, "Parameter order must be preserved")
+        }
+    }
+
+    // MARK: AC5 — per-cell failure isolation
+
+    /// A cell that throws in the factory must not prevent other cells from running.
+    func test_sweepWithVectStrategy_isolatesPerCellFailure() async {
+        let sym = Symbol("T")
+        let bars = makeBars(5, symbol: sym)
+        let config = makeConfig(bars: bars)
+        let space = ParameterSpace.grid([.ints("fail", [0, 1, 2])])
+        let sym2 = sym
+
+        let factory = ClosureStrategyFactory { params -> any Strategy in
+            if params.int("fail") == 1 {
+                throw NSError(domain: "TestError", code: 1)
+            }
+            return DefinedSignalStrategy(symbol: sym2, signalArray: [Bool](repeating: false, count: 5))
+        }
+        let results = await Sweep(
+            factory: factory,
+            runner: MLXBacktestRunner(),
+            bars: bars,
+            config: config,
+            space: space
+        ).run()
+
+        XCTAssertEqual(results.count, 3, "All 3 cells must return a result")
+        XCTAssertEqual(results[0].params.int("fail"), 0)
+        XCTAssertEqual(results[1].params.int("fail"), 1)
+        XCTAssertEqual(results[2].params.int("fail"), 2)
+        if case .failure = results[1].outcome {
+            // expected
+        } else {
+            XCTFail("Cell 1 must record a failure outcome")
+        }
+        if case .success = results[0].outcome {} else { XCTFail("Cell 0 must succeed") }
+        if case .success = results[2].outcome {} else { XCTFail("Cell 2 must succeed") }
+    }
+}
+
+// Money already conforms to Hashable (and thus Equatable) in AthenaCore.

--- a/Tests/AthenaMLXTests/VectorizedFillSimulatorTests.swift
+++ b/Tests/AthenaMLXTests/VectorizedFillSimulatorTests.swift
@@ -231,36 +231,9 @@ final class VectorizedFillSimulatorEquityTests: XCTestCase {
             commission: FreeCommission(currency: .usd),
             slippage: NoSlippage()
         )
-        // signals[0]=F, signals[1]=T → buy at bar[1].open=100 → 100 shares
-        // signals[2]=F → sell at bar[2+1=3].open... wait let me recheck
-        // Actually: signals[1]=true (transition from false to true) → buy at bar[1+1=2].open
-        // Wait, I need to re-check the logic.
-        //
-        // The transition happens BETWEEN consecutive signals.
-        // signals = [F, T, F, F]
-        // Transition 1: signals[0]=F → signals[1]=T: fill at bar[1].open? No...
-        //
-        // Per the contract: "A transition from false→true triggers a buy at the NEXT bar's open"
-        // signals[i] = desired position after bar i
-        // So signals[0]=F after bar 0, signals[1]=T after bar 1:
-        //   transition signals[0]→signals[1]: fills at bar[1+1=2]? No...
-        //
-        // Actually reading VectorizableStrategy more carefully:
-        // signals[i] = target after bar[i].close (i.e., based on seeing bar[i])
-        // The "next bar's open" = bar[i+1].open
-        //
-        // But my algorithm uses:
-        // At bar[i]: check signals[i-1] vs executedPosition → fill at bar[i].open
-        // = transition from signals[i-1] fills at bar[i].open
-        //
-        // So:
-        // signals = [F, T, F, F]
-        // bar[0]: i=0, no prev signal, skip
-        // bar[1]: i=1, check signals[0]=F vs executed=F → no transition
-        // bar[2]: i=2, check signals[1]=T vs executed=F → BUY at bar[2].open
-        // bar[3]: i=3, check signals[2]=F vs executed=T → SELL at bar[3].open
-        //
-        // So: buy at bar[2].open=100, sell at bar[3].open=100
+        // signals = [F, T, F, F]:
+        // bar[2]: signals[1]=T vs executed=F → BUY at bar[2].open=100
+        // bar[3]: signals[2]=F vs executed=T → SELL at bar[3].open=100
         XCTAssertEqual(result.fills.count, 2)
         let buyFill = result.fills.first(where: { $0.side == .buy })!
         let sellFill = result.fills.first(where: { $0.side == .sell })!
@@ -293,23 +266,11 @@ final class VectorizedFillSimulatorEquityTests: XCTestCase {
     /// open=100, fillPrice = 100 * (1 - 10/10_000) = 99.9
     func test_slippageReflectedInSellFillPrice() {
         let sym = Symbol("T")
-        // signals = [T, F, F] → buy at bar[1].open=100, sell at bar[2].open... wait
-        // signals = [F, T, F] → buy at bar[1], sell at bar[2]
-        // Actually:
-        // bar[0]: no prev, skip
-        // bar[1]: signals[0]=F vs executed=F → no fill
-        // bar[2]: signals[1]=T vs executed=F → BUY at bar[2].open=100
-        // end: signals[2]=F but it's the last; need sell at bar[3]?
-        // Hmm, signals=[F,T,F] with 3 bars:
-        // bar[2]: signals[1]=T → BUY at bar[2].open
-        // No bar[3] to execute signals[2]=F
-        // So only 1 fill (buy). Need 4 bars.
-        let bars = makeBars(4, symbol: sym, opens: [100, 100, 100, 100])
-        let signals = [false, true, false, false]
-        // bar[0]: skip
-        // bar[1]: signals[0]=F → no fill
+        // signals = [F, T, F, F] with 4 bars:
         // bar[2]: signals[1]=T → BUY at bar[2].open=100
         // bar[3]: signals[2]=F → SELL at bar[3].open=100
+        let bars = makeBars(4, symbol: sym, opens: [100, 100, 100, 100])
+        let signals = [false, true, false, false]
         let result = VectorizedFillSimulator().simulate(
             symbol: sym,
             signals: signals,

--- a/Tests/AthenaMLXTests/VectorizedIndicatorParityTests.swift
+++ b/Tests/AthenaMLXTests/VectorizedIndicatorParityTests.swift
@@ -288,6 +288,29 @@ final class VectorizedRSIParityTests: XCTestCase {
         }
     }
 
+    // MARK: Monotonically falling series
+
+    /// RSI on a strictly falling series equals 0 (all losses, no gains) and
+    /// matches the scalar implementation element-by-element.
+    ///
+    /// This exercises the downtrend path where `avgGain == 0`, driving
+    /// `rs == 0` and clamping RSI to 0 — a case the alternating series never
+    /// reaches because alternating inputs always produce non-zero gains.
+    func test_rsi_fallingSeries_matchesScalar() {
+        let period = 14
+        let closes = (1...30).reversed().map { Decimal($0) }
+        let vec    = VectorizedRSI(period: period).compute(closes: closes)
+        let scalar = scalarRSIValues(period: period, closes: closes)
+
+        XCTAssertEqual(vec.count, closes.count)
+        for (i, (v, s)) in zip(vec, scalar).enumerated() {
+            guard let v, let s else { continue }
+            // RSI uses pure Decimal arithmetic — enforce exact equality.
+            XCTAssertEqual(v, s,
+                           "RSI mismatch at bar \(i) on falling series: vec=\(v) scalar=\(s)")
+        }
+    }
+
     // MARK: Length contract
 
     /// Output length always equals input length.


### PR DESCRIPTION
## Why

PR #11 (vectorized fills, apl9000/hq#115) was merged into `feat/circuitry-vectorized-indicators` **after** that branch had already merged to main via PR #10 — so `VectorizedFillSimulator` and the real fast-path dispatch never reached main. Circuitry kept re-dispatching hq#115 against work that looked done.

## What

- Merge the stranded branch into main, resolving `MLXBacktestRunner` in favour of real vectorized dispatch (keeps #114's explicit fallback docs and routing).
- Rework `MLXEquivalenceGateTests` (#116) for the now-active fast path:
  - Cross-runner **fill structure** equivalence (count, timestamp, side, price) — equity metrics are not comparable across runners because the `VectorizableStrategy` contract is fully-in sizing at the next open, which an event-driven strategy cannot reproduce at submission time.
  - Vectorized metrics pinned to **golden values** from the seeded deterministic fixture — the drift net for the future MLX tensor swap.
  - Fixture pre-registers SMAs in `onStart` (documented one-bar lazy-registration caveat shifted crossovers at the SMA(50) warm-up boundary).

## Validation

`swift test`: 226 tests, 0 failures (macOS arm64).

Closes apl9000/hq#115 dependency; hq#115 will be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)