### PR TITLE
feat(mlx): add SignalFilter protocol and DebounceFilter

### DIFF
--- a/Sources/AthenaMLX/SignalFilter.swift
+++ b/Sources/AthenaMLX/SignalFilter.swift
@@ -8,7 +8,9 @@
 ///
 /// ## Invariant
 /// Every implementation must return an array whose `count` equals `signals.count`.
-/// Violating the length contract will cause a runtime trap via the precondition inside `VectorizedFillSimulator.simulate(...)`.
+/// Violating the length contract causes `MLXBacktestRunner` to throw
+/// `VectorizedFillSimulatorError.signalCountMismatch`, and traps the
+/// `precondition` inside `VectorizedFillSimulator.simulate(...)`.
 public protocol SignalFilter: Sendable {
     /// Apply the filter to a raw signal array.
     ///

--- a/Sources/AthenaMLX/SignalFilter.swift
+++ b/Sources/AthenaMLX/SignalFilter.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+// MARK: - SignalFilter
+
+/// A post-processor applied to a `VectorizableStrategy`'s boolean signal array
+/// before it reaches `VectorizedFillSimulator`.
+///
+/// Filters can be chained by composing them sequentially. Each filter receives
+/// the output of the previous one.
+///
+/// ## Invariant
+/// Every implementation must return an array whose `count` equals `signals.count`.
+/// Violating the length contract will cause a runtime trap in `MLXBacktestRunner`.
+public protocol SignalFilter: Sendable {
+    /// Apply the filter to a raw signal array.
+    ///
+    /// - Parameter signals: The raw `Bool` signals produced by
+    ///   `VectorizableStrategy.signals(for:)`.
+    /// - Returns: A filtered array of the same length as `signals`.
+    func filter(_ signals: [Bool]) -> [Bool]
+}
+
+// MARK: - DebounceFilter
+
+/// Suppresses rapid signal flips within `minBars` of the previous flip.
+///
+/// Useful for noisy strategies that flip in and out of a position on consecutive
+/// bars — debouncing reduces churn and can improve net-of-commission results.
+public struct DebounceFilter: SignalFilter {
+    /// The minimum number of bars that must elapse between two consecutive flips.
+    public let minBars: Int
+
+    public init(minBars: Int) {
+        self.minBars = minBars
+    }
+
+    public func filter(_ signals: [Bool]) -> [Bool] {
+        guard !signals.isEmpty else { return [] }
+        var result = signals
+        var lastFlipIndex = -minBars
+        for i in 1..<result.count {
+            if result[i] != result[i - 1] {
+                if i - lastFlipIndex < minBars {
+                    result[i] = result[i - 1]
+                } else {
+                    lastFlipIndex = i
+                }
+            }
+        }
+        return result
+    }
+}

--- a/Sources/AthenaMLX/SignalFilter.swift
+++ b/Sources/AthenaMLX/SignalFilter.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // MARK: - SignalFilter
 
 /// A post-processor applied to a `VectorizableStrategy`'s boolean signal array
@@ -10,7 +8,7 @@ import Foundation
 ///
 /// ## Invariant
 /// Every implementation must return an array whose `count` equals `signals.count`.
-/// Violating the length contract will cause a runtime trap in `MLXBacktestRunner`.
+/// Violating the length contract will cause a runtime trap via the precondition inside `VectorizedFillSimulator.simulate(...)`.
 public protocol SignalFilter: Sendable {
     /// Apply the filter to a raw signal array.
     ///
@@ -28,9 +26,12 @@ public protocol SignalFilter: Sendable {
 /// bars — debouncing reduces churn and can improve net-of-commission results.
 public struct DebounceFilter: SignalFilter {
     /// The minimum number of bars that must elapse between two consecutive flips.
+    ///
+    /// Must be non-negative. Passing a negative value will trigger a precondition failure.
     public let minBars: Int
 
     public init(minBars: Int) {
+        precondition(minBars >= 0, "minBars must be non-negative")
         self.minBars = minBars
     }
 

--- a/Tests/AthenaMLXTests/SignalFilterTests.swift
+++ b/Tests/AthenaMLXTests/SignalFilterTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import AthenaCore
 @testable import AthenaMLX
 
 final class DebounceFilterTests: XCTestCase {
@@ -8,7 +7,7 @@ final class DebounceFilterTests: XCTestCase {
 
     func test_debounceFilter_conformsToSignalFilter() {
         let filter: any SignalFilter = DebounceFilter(minBars: 2)
-        XCTAssertNotNil(filter)  // existential is non-optional; this always passes
+        XCTAssertTrue(filter is DebounceFilter)
     }
 
     // MARK: Empty input
@@ -16,7 +15,6 @@ final class DebounceFilterTests: XCTestCase {
     func test_debounceFilter_emptyInput_returnsEmptyOutput() {
         let filter = DebounceFilter(minBars: 2)
         let result = filter.filter([])
-        XCTAssertNotNil(result)  // [Bool] is non-optional; this always passes
         XCTAssertTrue(result.isEmpty)
     }
 
@@ -26,7 +24,6 @@ final class DebounceFilterTests: XCTestCase {
         let filter = DebounceFilter(minBars: 3)
         let signals = [true, false, true, false, true, false]
         let result = filter.filter(signals)
-        XCTAssertNotNil(result)  // [Bool] is non-optional; this always passes
         XCTAssertEqual(result.count, signals.count)
     }
 
@@ -37,8 +34,8 @@ final class DebounceFilterTests: XCTestCase {
         let filter = DebounceFilter(minBars: 3)
         let signals = [false, true, false, false, false]
         let result = filter.filter(signals)
-        XCTAssertEqual(result, [false, true, true, false, false],
-                       "Second flip at i=2 must be suppressed — within 3-bar debounce window")
+        XCTAssertEqual(result, [false, true, true, true, false],
+                       "Flips at i=2 and i=3 must both be suppressed — within 3-bar debounce window")
     }
 
     func test_debounceFilter_allowsFlipAfterWindow() {
@@ -46,7 +43,6 @@ final class DebounceFilterTests: XCTestCase {
         let filter = DebounceFilter(minBars: 3)
         let signals = [false, true, true, true, false]
         let result = filter.filter(signals)
-        XCTAssertNotNil(result)  // [Bool] is non-optional; this always passes
         XCTAssertEqual(result[4], false,
                        "Flip at i=4 must pass through — gap of 3 meets the minBars threshold")
     }

--- a/Tests/AthenaMLXTests/SignalFilterTests.swift
+++ b/Tests/AthenaMLXTests/SignalFilterTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import AthenaCore
+@testable import AthenaMLX
+
+final class DebounceFilterTests: XCTestCase {
+
+    // MARK: Conformance
+
+    func test_debounceFilter_conformsToSignalFilter() {
+        let filter: any SignalFilter = DebounceFilter(minBars: 2)
+        XCTAssertNotNil(filter)  // existential is non-optional; this always passes
+    }
+
+    // MARK: Empty input
+
+    func test_debounceFilter_emptyInput_returnsEmptyOutput() {
+        let filter = DebounceFilter(minBars: 2)
+        let result = filter.filter([])
+        XCTAssertNotNil(result)  // [Bool] is non-optional; this always passes
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: Length invariant
+
+    func test_debounceFilter_preservesSignalCount() {
+        let filter = DebounceFilter(minBars: 3)
+        let signals = [true, false, true, false, true, false]
+        let result = filter.filter(signals)
+        XCTAssertNotNil(result)  // [Bool] is non-optional; this always passes
+        XCTAssertEqual(result.count, signals.count)
+    }
+
+    // MARK: Debounce behaviour
+
+    func test_debounceFilter_suppressesFlipWithinWindow() {
+        // flip at i=1, then flip-back at i=2 — within 3-bar window, suppress i=2
+        let filter = DebounceFilter(minBars: 3)
+        let signals = [false, true, false, false, false]
+        let result = filter.filter(signals)
+        XCTAssertEqual(result, [false, true, true, false, false],
+                       "Second flip at i=2 must be suppressed — within 3-bar debounce window")
+    }
+
+    func test_debounceFilter_allowsFlipAfterWindow() {
+        // flip at i=1, next at i=4 — gap of 3 meets the minBars=3 threshold
+        let filter = DebounceFilter(minBars: 3)
+        let signals = [false, true, true, true, false]
+        let result = filter.filter(signals)
+        XCTAssertNotNil(result)  // [Bool] is non-optional; this always passes
+        XCTAssertEqual(result[4], false,
+                       "Flip at i=4 must pass through — gap of 3 meets the minBars threshold")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SignalFilter` protocol to `AthenaMLX` — a post-processing layer for `VectorizableStrategy` boolean signal arrays applied before `VectorizedFillSimulator`
- Adds `DebounceFilter` concrete implementation that suppresses rapid signal flips within `minBars` of the previous flip
- Adds `DebounceFilterTests` with 5 test cases covering conformance, empty input, length invariant, and debounce behaviour

## Motivation

Noisy strategies frequently flip in/out on consecutive bars, generating excessive commissions. A filter layer lets callers tune churn independently from signal logic.

## Test plan

- [ ] `swift build` passes
- [ ] `swift test` passes — 5 new tests added, 0 failures

---

> **Note (circuitry hq#165):** This PR is the substitute live-run target for the `pr-review-fixer` supervised run. The original target (athena PR #8) merged on 2026-07-22 with all threads outdated. This PR contains deliberate code-quality issues (unused `import Foundation`, missing `minBars` precondition documentation, and ineffective `XCTAssertNotNil` on non-optional types) that `copilot-pull-request-reviewer` can flag, enabling a genuine supervised run of `circuitry worker --once --routine pr-review-fixer --profile ProjectProfiles/athena.json`.